### PR TITLE
Re-instated the split between wrap-convert-suffix-to-accept-header and wrap-browser-safe-content-type

### DIFF
--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -87,10 +87,8 @@ preference."
         (-> request
             (assoc-in [:headers "accept"] media-type)
             (assoc :uri (.substring uri 0 (- (count uri) (count suffix))))
-            handler
-            (assoc-in [:headers "Content-Type"] media-type))
+            handler)
         (handler request)))))
-
 
 (defmulti render-map-generic "dispatch on media type"
   (fn [data context] (get-in context [:representation :media-type])))


### PR DESCRIPTION
Fixed a bug with wrap-convert-suffix-to-accept-header that meant that any response that wasn't html/xhtml or xml was having it's Content-Type response header set to "text/plain". I've fixed this by splitting it into two middlewares, wrap-convert-suffix-to-accept-header and wrap-browser-safe-content-type (the latter makes it far more explicit that Liberator is changing response headers on your behalf)

I understand that there's currently a debate ongoing about whether either of these two middlewares belong in liberator - a good question! 

Regardless of the outcome of this debate, the existing behaviour is counter-intuitive and has caught me out more than once - so, in the meantime, I thought I'd re-apply this fix.

It's good to see the amount of development activity on this library at the moment, thanks!

James
