### PR TITLE
lic sec of readme should read 'Liber is licensed...' instead of 'Compoju...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -255,4 +255,4 @@ available-* = option
 
 # License
 
-Compojure-rest is licensed under EPL 1.0 (see file epl-v10.html).
+Liberator is licensed under EPL 1.0 (see file epl-v10.html).


### PR DESCRIPTION
At the end of the README there is a reference to "Compojure-rest" which seems like it should be updated to "Liberator".
