### PR TITLE
de-complect ring response generation from representation

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -11,14 +11,14 @@
   (:use
    [liberator.util :only [parse-http-date http-date as-date]]
    [clojure.tools.trace :only [trace]]
-   [liberator.representation :only [Representation as-response ring-response]])
+   [liberator.representation :only [Representation as-ring-response ring-response]])
   (:import (javax.xml.ws ProtocolException)))
 
 (defmulti coll-validator
-  "Return a function that evaluaties if the give argument 
-             a) is contained in a collection 
+  "Return a function that evaluaties if the give argument
+             a) is contained in a collection
              b) equals an argument
-             c) when applied to a function evaluates as true" 
+             c) when applied to a function evaluates as true"
   (fn [x] (cond
           (coll? x) :col
           (fn? x) :fn)))
@@ -30,10 +30,10 @@
 (defmethod coll-validator :default [x]
   (partial = x))
 
-(defn console-logger [category values] 
+(defn console-logger [category values]
   #(apply println "LOG " category " " values))
 
-(def ^:dynamic *loggers* nil) 
+(def ^:dynamic *loggers* nil)
 
 (defmacro with-logger [logger & body]
   `(binding [*loggers* (conj (or *loggers* []) ~logger)]
@@ -82,7 +82,7 @@
    :otherwise newval))
 
 (defn decide [name test then else {:keys [resource request] :as context}]
-  (if (or (fn? test) (contains? resource name)) 
+  (if (or (fn? test) (contains? resource name))
     (let [ftest (or (resource name) test)
 	  ftest (make-function ftest)
 	  fthen (make-function then)
@@ -102,7 +102,7 @@
   `(defn ~name [~'context]
      (decide ~(keyword name) ~test ~then ~else ~'context)))
 
-(defmacro defdecision 
+(defmacro defdecision
   ([name then else]
      (defdecision* name nil then else))
   ([name test then else]
@@ -129,7 +129,7 @@
                    {:keys [resource request representation] :as context}]
   (let [context
         (merge {:status status :message message} context)
-        response 
+        response
         (merge-with
          combine
 
@@ -139,19 +139,19 @@
          ;; ETags
          (when-let [etag (gen-etag context)]
            {:headers {"ETag" etag}})
-         
+
          ;; Last modified
          (when-let [last-modified (gen-last-modified context)]
            {:headers {"Last-Modified" (http-date last-modified)}})
-     
+
          (if-let [handler (get resource (keyword name))]
            (do
              (log! :handler (keyword name))
-             ;; Content negotiations         
+             ;; Content negotiations
              (merge-with
               merge
               {:headers
-               (-> {} 
+               (-> {}
                    (set-header-maybe "Content-Type"
                                      (str (:media-type representation)
                                           (when-let [charset (:charset representation)] (str ";charset=" charset))))
@@ -166,12 +166,12 @@
               ;; The rules about who should take responsibility for encoding
               ;; the response are defined in the BodyResponse protocol.
               (let [handler-response (handler context)
-                    response (as-response handler-response context)]
+                    response (as-ring-response handler-response context)]
                 ;; We get an obscure 'cannot be cast to java.util.Map$Entry'
                 ;; error if our BodyResponse function doesn't return a map,
                 ;; so we check it now.
                 (when-not (or (map? response) (nil? response))
-                  (throw (Exception. (format "%s as-response function did not return a map (or nil) for instance of %s"
+                  (throw (Exception. (format "%s as-ring-response function did not return a map (or nil) for instance of %s"
                                              'Representation (type handler-response)))))
                 response)))
 
@@ -179,8 +179,8 @@
            ;; have so far.
            (let [message (get context :message)]
              (do (log! :handler (keyword name) "(default implementation)")
-                 {:status status 
-                  :headers {"Content-Type" "text/plain"} 
+                 {:status status
+                  :headers {"Content-Type" "text/plain"}
                   :body (if (fn? message) (message context) message)}))))]
     (if-not (= :head (:request-method request))
       response
@@ -278,14 +278,14 @@
 
 (defhandler handle-precondition-failed 412 "Precondition failed.")
 
-(defdecision if-match-star-exists-for-missing? 
+(defdecision if-match-star-exists-for-missing?
   if-match-star
   handle-precondition-failed
   method-put?)
 
 (defhandler handle-not-modified 304 nil)
 
-(defdecision if-none-match? 
+(defdecision if-none-match?
   #(#{ :head :get} (get-in % [:request :request-method]))
   handle-not-modified
   handle-precondition-failed)
@@ -293,7 +293,7 @@
 (defdecision put-to-existing? (partial =method :put)
   conflict? multiple-representations?)
 
-(defdecision post-to-existing? (partial =method :post) 
+(defdecision post-to-existing? (partial =method :post)
   post! put-to-existing?)
 
 (defhandler handle-accepted 202 "Accepted")
@@ -316,7 +316,7 @@
   handle-not-modified)
 
 (defdecision if-modified-since-valid-date?
-  (fn [context] 
+  (fn [context]
     (if-let [date (parse-http-date (get-in context [:request :headers "if-modified-since"]))]
       {::if-modified-since-date date}))
   modified-since?
@@ -335,7 +335,7 @@
   if-none-match?
   if-modified-since-exists?)
 
-(defdecision if-none-match-star? 
+(defdecision if-none-match-star?
   #(= "*" (get-in % [:request :headers "if-none-match"]))
   if-none-match?
   etag-matches-for-if-none?)
@@ -354,7 +354,7 @@
   if-none-match-exists?)
 
 (defdecision  if-unmodified-since-valid-date?
-  (fn [context]   
+  (fn [context]
     (if-let [date (parse-http-date (get-in context [:request :headers  "if-unmodified-since"]))]
       (assoc context ::if-unmodified-since-date date) context))
   unmodified-since?
@@ -371,7 +371,7 @@
   if-unmodified-since-exists?
   handle-precondition-failed)
 
-(defdecision if-match-star? 
+(defdecision if-match-star?
   if-match-star if-unmodified-since-exists? etag-matches-for-if-match?)
 
 (defdecision if-match-exists? (partial header-exists? "if-match")
@@ -381,7 +381,7 @@
 
 (defhandler handle-not-acceptable 406 "No acceptable resource available.")
 
-(defdecision encoding-available? 
+(defdecision encoding-available?
   (fn [ctx]
     (when-let [encoding (conneg/best-allowed-encoding
                          (get-in ctx [:request :headers "accept-encoding"])
@@ -416,7 +416,7 @@
 (defdecision language-available?
   #(try-header "Accept-Language"
                (when-let [lang (conneg/best-allowed-language
-                                (get-in % [:request :headers "accept-language"]) 
+                                (get-in % [:request :headers "accept-language"])
                                 ((get-in context [:resource :available-languages]) context))]
                  (if (= lang "*")
                    true
@@ -428,8 +428,8 @@
 
 (defn negotiate-media-type [context]
   (try-header "Accept"
-              (when-let [type (conneg/best-allowed-content-type 
-                               (get-in context [:request :headers "accept"]) 
+              (when-let [type (conneg/best-allowed-content-type
+                               (get-in context [:request :headers "accept"])
                                ((get-in context [:resource :available-media-types] "text/html") context))]
                 {:representation {:media-type (conneg/stringify type)}})))
 
@@ -443,7 +443,7 @@
      ;; client accepts all media types" [p100]
      ;; in this case we do content-type negotiaion using */* as the accept
      ;; specification
-     (if-let [type (liberator.conneg/best-allowed-content-type 
+     (if-let [type (liberator.conneg/best-allowed-content-type
                     "*/*"
                     ((get-in context [:resource :available-media-types]) context))]
        [false {:representation {:media-type (liberator.conneg/stringify type)}}]
@@ -490,7 +490,7 @@
        :as ctx}]
     (some #{m} (vm ctx))))
 
-(def default-functions 
+(def default-functions
   {
    ;; Decisions
    :service-available?        true
@@ -530,7 +530,7 @@
    :handle-see-other          handle-moved
    :handle-moved-temporarily  handle-moved
    :handle-moved-permanently  handle-moved
-   
+
 
    ;; Imperatives. Doesn't matter about decision outcome, both
    ;; outcomes follow the same route.
@@ -557,7 +557,7 @@
                          :resource
                          (map-values make-function (merge default-functions kvs))
                          :representation {}})
-    
+
     (catch ProtocolException e         ; this indicates a client error
       {:status 400
        :headers {"Content-Type" "text/plain"}
@@ -574,7 +574,7 @@
       `(defn ~name [~@args]
          (fn [request#]
            (run-resource request# ~(apply hash-map kvs)))))
-    `(defn ~name [request#] 
+    `(defn ~name [request#]
        (run-resource request# ~(apply hash-map kvs)))))
 
 (defn by-method
@@ -587,4 +587,3 @@
                :delete \"Entity was deleted successfully.\"})"
   [map]
   (fn [ctx] ((make-function (get map (get-in ctx [:request :request-method]) ctx)) ctx)))
-

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -208,7 +208,7 @@
     (into (empty this) (map #(as-response % context) this)))
 
   clojure.lang.Keyword
-  (as-response [this _] (name this))
+  (as-response [this _] this)
 
   clojure.lang.Symbol
   (as-response [this _] (name this))

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -248,6 +248,8 @@
                          (get representation :media-type "text/plain")
                          charset)}}))
 
+(defmethod as-ring-response nil [_ _] nil)
+
 (defmethod as-ring-response :default
   [data context]
   (as-ring-response (render-item (as-response data context) context) context))

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -145,7 +145,7 @@
                    :newline :cr+lf :separator sep)))
 
 (defmethod render-seq-generic "text/csv" [data context]
-   (render-seq-csv data context \,))
+  (render-seq-csv data context \,))
 
 (defmethod render-seq-generic "text/tab-separated-values" [data context]
   (render-seq-csv data context \tab))

--- a/test/test_representation.clj
+++ b/test/test_representation.clj
@@ -13,7 +13,7 @@
 (facts "Can produce representations from map"
        (let [entity {:foo "bar" :baz "qux"}]
          (tabular "Various media types are supported"
-                  (as-response entity {:representation {:media-type ?media-type :charset "UTF-8"}})
+                  (as-ring-response entity {:representation {:media-type ?media-type :charset "UTF-8"}})
                   => {:body ?body :headers { "Content-Type" (str ?media-type ";charset=UTF-8")}}
                   ?media-type   ?body
                   "text/csv"    "name,value\r\n:foo,bar\r\n:baz,qux\r\n"
@@ -30,7 +30,7 @@
 (facts "Can produce representations from a seq of maps"
        (let [entity [{:foo 1 :bar 2} {:foo 2 :bar 3}]]
          (tabular "Various media types are supported"
-                  (as-response entity {:representation {:media-type ?media-type :charset "UTF-8"}})
+                  (as-ring-response entity {:representation {:media-type ?media-type :charset "UTF-8"}})
                   => {:body ?body :headers { "Content-Type" (str ?media-type ";charset=UTF-8")}}
                   ?media-type   ?body
                   "text/csv"    "foo,bar\r\n1,2\r\n2,3\r\n"
@@ -46,5 +46,3 @@
                   "application/json" (clojure.data.json/write-str entity)
                   "application/clojure" (pr-str-dup entity)
                   "application/edn" (pr-str-dup entity))))
-
-

--- a/test/test_representation.clj
+++ b/test/test_representation.clj
@@ -46,3 +46,31 @@
                   "application/json" (clojure.data.json/write-str entity)
                   "application/clojure" (pr-str-dup entity)
                   "application/edn" (pr-str-dup entity))))
+
+(facts "Can produce representations from strings"
+  (let [entity "Testing liberator"]
+    (tabular "Various media types are supported"
+             (as-ring-response entity {:representation {:media-type ?media-type :charset "UTF-8"}})
+             => {:body ?body :headers { "Content-Type" (str ?media-type ";charset=UTF-8")}}
+             ?media-type   ?body
+             "text/csv"    "Testing liberator"
+             "text/tab-separated-values" "Testing liberator"
+             "text/plain"  "Testing liberator"
+             "text/html"   "Testing liberator"
+             "application/json" "Testing liberator"
+             "application/clojure" "Testing liberator"
+             "application/edn" "Testing liberator")))
+
+(facts "Can produce representations from dates"
+  (let [entity (java.util.Date.)]
+    (tabular "Various media types are supported"
+             (as-ring-response entity {:representation {:media-type ?media-type :charset "UTF-8"}})
+             => {:body ?body :headers { "Content-Type" (str ?media-type ";charset=UTF-8")}}
+             ?media-type   ?body
+             "text/csv"    (str entity)
+             "text/tab-separated-values" (str entity)
+             "text/plain"  (str entity)
+             "text/html"   (str entity)
+             "application/json" (str entity)
+             "application/clojure" (str entity)
+             "application/edn" (str entity))))


### PR DESCRIPTION
This change allows implementations of the Representation protocol to act on values nested inside data structures.

So, for example, if I have `defrecord Foo` in my code and extend the Representation protocol for Foo's, that will work if my handlers return one Foo record, but it would fail if a handler returned a vector of Foo's (because the render-seq-generic would hand off that vector to the output encoder, which wouldn't know how to handle Foo records).

We're unable to get the test suite to run locally, so we haven't written any tests around this (or updated the existing tests). If someone can help us figure out the problem there (I posted to the Google Group about it), then we'd be happy to add test coverage and update the existing tests.