### PR TITLE
enable decisions to return functions as well as truthy values

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -155,8 +155,9 @@ Depending on how far the processing of the request has got, the map may also con
 The function must be return one of the following :-
 
 * A boolean, determining the next step in the decision tree.
+* A function that takes the context and calls an alternate decision, action or handler
 * A map to be merged with the context, indicating a true value.
-* A vector pair containing a boolean as the first item and a map as the second item.
+* A vector pair containing a boolean or function as the first item and a map as the second item.
 
 ## Handlers
 
@@ -208,7 +209,7 @@ you should check examples and documentation.
 
 Examples can be found in the examples/ dir.
 
-# Reference: List of decisions
+# Reference: List of out-of-the-box decisions
 
 Decision points can be :-
 
@@ -270,6 +271,9 @@ available-* = option
 .*\? = decision
 .*\! = action
 :else handler
+
+New decisions, actions, and handlers can be defined and spliced into the
+decision-graph by returning a function from a decision instead of a boolean.
 
 # License
 

--- a/examples/clj/examples.clj
+++ b/examples/clj/examples.clj
@@ -3,7 +3,7 @@
             [clojure.java.io :as io]
             [clojure.data.json :as json]
             [liberator.dev :as dev])
-  (:use [liberator.core :only [defresource request-method-in]]
+  (:use [liberator.core :only [defresource defhandler request-method-in]]
         [liberator.representation :only [Representation]]
         [compojure.core :only [context ANY routes defroutes]]
         [hiccup.page :only [html5]]
@@ -140,6 +140,17 @@
                         [:li [:a {:href "/drag-drop"} "Drag and Drop (featuring clojure script)"]]
                         [:li [:a {:href "/drag-drop/athletes"} "Athletes"]]
                         [:li [:a {:href "/x-liberator/requests/"} "Liberator request dump"]]]]))) 
+
+(defhandler handle-unprocessable-entity 422 "Entity is invalid")
+
+(defresource simple-splice
+  :method-allowed? (request-method-in :get :post)
+  :available-media-types ["text/html"]
+  :post! (fn [ctx]
+           (if (= "pass" (get-in ctx [:request :params :flag]))
+             true ; continue on default processing path
+             #(handle-unprocessable-entity %))) ;change default flow to new handler
+  :handle-created "Created")
 
 (defn assemble-routes []
   (->

--- a/examples/clj/examples.clj
+++ b/examples/clj/examples.clj
@@ -146,10 +146,10 @@
 (defresource simple-splice
   :method-allowed? (request-method-in :get :post)
   :available-media-types ["text/html"]
-  :post! (fn [ctx]
-           (if (= "pass" (get-in ctx [:request :params :flag]))
-             true ; continue on default processing path
-             #(handle-unprocessable-entity %))) ;change default flow to new handler
+  :post-to-existing? (fn [ctx]
+                          (if (= "pass" (get-in ctx [:request :params :flag]))
+                            true ; process as normal
+                            handle-unprocessable-entity)) ; change
   :handle-created "Created")
 
 (defn assemble-routes []

--- a/examples/clj/splice.clj
+++ b/examples/clj/splice.clj
@@ -47,7 +47,7 @@
   :new? (fn [ctx] (=method :post ctx))
   :post-to-existing? (fn [ctx]
                        (if (=method :post ctx)
-                         #(post-entity-valid? %)
+                         post-entity-valid?
                          false))
   :post-entity-valid? (fn [ctx]
                         (let [entity (request->ToDo (get ctx :request))]
@@ -56,7 +56,7 @@
            (swap! todo-list conj (:entity ctx)))
   :handle-created "Created"
 
-  :conflict? (fn [_] #(put-entity-valid? %))
+  :conflict? (constantly put-entity-valid?)
   :put-entity-valid? (fn [ctx]
                        (let [entity (request->ToDo (get ctx :request))]
                          [(.valid? entity :update) {:entity entity}]))

--- a/examples/clj/splice.clj
+++ b/examples/clj/splice.clj
@@ -1,0 +1,71 @@
+(ns splice
+  (:require [liberator.dev :as dev])
+  (:use [liberator.core :only [defresource defhandler defdecision request-method-in post! put! handle-conflict =method]]
+        [compojure.core :only [ANY routes]]))
+
+; simulated domain model
+(def todo-list (atom []))
+
+(defn todo-by-name [name]
+  (first (filter #(= name (get % :name)) @todo-list)))
+
+(defprotocol Validatable
+  (valid? [_ _]))
+
+(defrecord ToDo [name checked]
+  Validatable
+  (valid? [this save-context]
+    (let [valid (if (= :create save-context)
+                  (not (or (or (empty? name) (= name "invalid")) ; has to have a valid name
+                           (not (nil? (todo-by-name name))) ; name must not be present
+                           (nil? checked)))
+                  ; update
+                  (not (or (empty? name)         ; has to have a name
+                           (nil? (todo-by-name name))    ; name must be present
+                           )))]
+      valid)))
+
+(defn request->ToDo
+  [request]
+  (if-let [params (or (:params request) (:form-params request))]
+    (->ToDo (:name params) (or (:checked params) false))
+    (->ToDo nil nil)))
+
+; new handlers and decisions
+
+(defhandler handle-unprocessable-entity 422 "Entity is invalid")
+
+(defdecision post-entity-valid? post! handle-unprocessable-entity)
+
+(defdecision put-entity-valid?  put! handle-unprocessable-entity)
+
+; resource that splices is new flows
+
+(defresource todo
+  :method-allowed? (request-method-in :get :post :put)
+  :available-media-types ["text/html"]
+  :new? (fn [ctx] (=method :post ctx))
+  :post-to-existing? (fn [ctx]
+                       (if (=method :post ctx)
+                         #(post-entity-valid? %)
+                         false))
+  :post-entity-valid? (fn [ctx]
+                        (let [entity (request->ToDo (get ctx :request))]
+                          [(.valid? entity :create) {:entity entity}]))
+  :post! (fn [ctx]
+           (swap! todo-list conj (:entity ctx)))
+  :handle-created "Created"
+
+  :conflict? (fn [_] #(put-entity-valid? %))
+  :put-entity-valid? (fn [ctx]
+                       (let [entity (request->ToDo (get ctx :request))]
+                         [(.valid? entity :update) {:entity entity}]))
+  ; fake put here
+  :put! (constantly true)
+  :handle-no-content "Updated")
+
+(defn assemble-routes []
+  (->
+   (routes
+    (ANY "/todo" [] todo))
+   (dev/wrap-trace :ui :header)))

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -93,7 +93,9 @@
 	  context (if (map? context-update)
                     (combine context context-update) context)]
       (log! :decision name decision)
-      ((if result fthen felse) context))
+      (if (fn? result)
+        (result context)
+        ((if result fthen felse) context)))
     {:status 500 :body (str "No handler found for key \""  name "\"."
                             " Keys defined for resource are " (keys resource))}))
 
@@ -186,7 +188,7 @@
       response
       (dissoc response :body))))
 
-(defmacro ^:private defhandler [name status message]
+(defmacro defhandler [name status message]
   `(defn ~name [context#]
      (run-handler '~name ~status ~message context#)))
 

--- a/test/test_examples.clj
+++ b/test/test_examples.clj
@@ -2,8 +2,9 @@
   (:require examples)
   (:use
    [liberator.representation :only [->when]]
-   [ring.mock.request :only [request header]]
+   [ring.mock.request :as mock :only [request header]]
    [compojure.core :only [ANY]]
+   [compojure.handler :only [api]]
    [liberator.core  :only [resource with-console-logger]]
    [midje.sweet :only [fact facts truthy against-background contains future-fact future-facts defchecker tabular before]]
    [checkers]))
@@ -69,3 +70,18 @@
    "text/html"          ["text/html"]      200        "text/html;charset=UTF-8"
    "text/plain"         ["text/html"]      406         "text/plain"))
 
+(facts "about splice"
+  (tabular
+   (facts "about posting"
+     (let [handler (api (ANY "/splice" [] examples/simple-splice))
+           req (-> (request :post "/splice")
+                   (mock/body ?body))
+           response (handler req)]
+       (fact "has expected status"
+         response => (contains {:status ?status}))
+       (fact "has expected content"
+         response => (body ?result))))
+   ?body                ?status             ?result
+   {:flag "pass"}       201                 "Created"
+   {:flag "fail"}       422                 "Entity is invalid"
+   {}                   422                 "Entity is invalid"))

--- a/test/test_splice.clj
+++ b/test/test_splice.clj
@@ -1,0 +1,56 @@
+(ns test-splice
+  (:require [splice :refer [todo-list todo ->ToDo]]
+            [ring.mock.request :as mock :refer [request header]]
+            [compojure.core :refer [ANY]]
+            [compojure.handler :refer [api]]
+            [midje.sweet :refer [fact facts truthy against-background contains future-fact future-facts defchecker tabular before]]
+            [checkers :refer :all]))
+
+(facts "about POST"
+  (tabular
+   (facts "with empty list"
+     (with-state-changes [(before :facts (reset! todo-list []))]
+       (let [handler (api (ANY "/todo" [] todo))
+             req (-> (request :post "/todo")
+                     (mock/body ?body))
+             response (handler req)]
+         (fact "has expected status"
+           response => (contains {:status ?status}))
+         (fact "has expected content"
+           response => (body ?result)))))
+   ?body                           ?status            ?result
+   {:name "Do it" :checked false}  201                "Created"
+   {:name "It Do"}                 201                "Created"
+   {:name "invalid"}               422                "Entity is invalid"
+   {}                              422                "Entity is invalid")
+
+  (tabular
+   (with-state-changes [(before :facts (reset! todo-list [(->ToDo "Buy Milk" false)]))]
+     (facts "with an existing ToDo"
+       (let [handler (api (ANY "/todo" [] todo))
+             req (-> (request :post "/todo")
+                     (mock/body ?body))
+             response (handler req)]
+         (fact "has expected status"
+           response => (contains {:status ?status}))
+         (fact "has expected content"
+           response => (body ?result)))))
+   ?body                          ?status            ?result
+   {:name "Buy Milk"}             422                "Entity is invalid"
+   {:name "Buy Soda"}             201                "Created"))
+
+(facts "about PUT"
+  (tabular
+   (with-state-changes [(before :facts (reset! todo-list [(->ToDo "Buy Milk" false)]))]
+     (facts "with an existing ToDo"
+       (let [handler (api (ANY "/todo" [] todo))
+             req (-> (request :put "/todo")
+                     (mock/body ?body))
+             response (handler req)]
+         (fact "has expected status"
+           response => (contains {:status ?status}))
+         (fact "has expected content"
+           response => (body ?result)))))
+   ?body                            ?status            ?result
+   {:name "Buy Milk" :checked true} 204                "Updated"
+   {:name "Buy Soda"}               422                "Entity is invalid"))


### PR DESCRIPTION
Small change to core.clj which allows a decision to return a function in the truthy position, thus allowing the execution path to be altered beyond the preset values. Also by exposing defhandler, new handlers can be defined and the execution path can be altered to use these new handlers. In this manner, for instance, someone can create and use a handler to handle the 422 unprocessable entity code.

To see more, check out examples/clj/splice.clj which introduces new decision points that an application might use to test the validity of posted or put data and direct to a new unprocessable-entity handler if validation fails.

Ultimately I wanted a way to redefine decisions in the context of my application, but the nature of how they are created prevents this without larger changes. This solution was the simplest way I could see to retain the speed advantage of a largely static execution path.
