### PR TITLE
Add 422 unprocessable

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -376,6 +376,9 @@
 
 (defdecision exists? if-match-exists? if-match-star-exists-for-missing?)
 
+(defhandler handle-unprocessable-entity 422 "Unprocessable entity.")
+(defdecision processable? exists? handle-unprocessable-entity)
+
 (defhandler handle-not-acceptable 406 "No acceptable resource available.")
 
 (defdecision encoding-available? 
@@ -385,7 +388,7 @@
                          ((get-in ctx [:resource :available-encodings]) ctx))]
       {:representation {:encoding encoding}}))
 
-  exists? handle-not-acceptable)
+  processable? handle-not-acceptable)
 
 (defmacro try-header [header & body]
   `(try ~@body
@@ -394,7 +397,7 @@
                   (format "Malformed %s header" ~header) e#)))))
 
 (defdecision accept-encoding-exists? (partial header-exists? "accept-encoding")
-  encoding-available? exists?)
+  encoding-available? processable?)
 
 (defdecision charset-available?
   #(try-header "Accept-Charset"
@@ -521,6 +524,7 @@
    :moved-permanently?        false
    :moved-temporarily?        false
    :delete-enacted?           true
+   :processable?              true
 
    ;; Handlers
    :handle-ok                 "OK"

--- a/test/test_flow.clj
+++ b/test/test_flow.clj
@@ -109,6 +109,11 @@
       resp (r (request :put "/"))]
   (fact "Put to missing can give 201" resp => CREATED))
 
+(let [r (resource :method-allowed? [:put]
+                  :processable? false)
+      resp (r (request :put "/"))]
+  (fact "Unprocessable can give 422" resp => (is-status 422)))
+
 (facts "Head requests"
   (facts "on existing resource"
     (let [resp ((resource :exists? true :handle-ok "OK") (request :head "/"))]


### PR DESCRIPTION
422 unprocessable seems most appropriate for cases where a client's data is invalid.

Right now, this is how I handle invalid data:

``` clojure
:malformed? (fn [_]
                (if-valid
                 params validations/topic errors
                 false
                 [true {:errors errors
                        :representation {:media-type "application/json"}}]))
```

So, another drawback of not having 422 is that you have to explicitly add the media-type to the context map, which I don't think you should need to do.
