### PR TITLE
Fix EDN problem with printing type info

### DIFF
--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -77,11 +77,15 @@
   (binding [*print-dup* true]
     (with-out-str (pr data))))
 
+(defn render-as-edn [data]
+  (binding [*print-dup* false]
+    (with-out-str (pr data))))
+
 (defmethod render-map-generic "application/clojure" [data context]
   (render-as-clojure data))
 
 (defmethod render-map-generic "application/edn" [data context]
-  (render-as-clojure data))
+  (render-as-edn data))
 
 (defn- render-map-html-table
   [data
@@ -133,7 +137,7 @@
   (render-as-clojure data))
 
 (defmethod render-seq-generic "application/edn" [data _]
-  (render-as-clojure data))
+  (render-as-edn data))
 
 (defn render-seq-csv
   [data

--- a/test/test_representation.clj
+++ b/test/test_representation.clj
@@ -25,7 +25,7 @@
                                      "</tbody></table></div>")
                   "application/json" (clojure.data.json/write-str entity)
                   "application/clojure" (pr-str-dup entity)
-                  "application/edn" (pr-str-dup entity))))
+                  "application/edn" (pr-str entity))))
 
 (facts "Can produce representations from a seq of maps"
        (let [entity [{:foo 1 :bar 2} {:foo 2 :bar 3}]]
@@ -45,6 +45,6 @@
                                      "</table></div>")
                   "application/json" (clojure.data.json/write-str entity)
                   "application/clojure" (pr-str-dup entity)
-                  "application/edn" (pr-str-dup entity))))
+                  "application/edn" (pr-str entity))))
 
 


### PR DESCRIPTION
EDN was using the render-as-clojure function, which was setting _print-dup_ to true, which had the effect of printing type info along with the object. For "{:a 1 :b 2}" for example, it printed "#=(clojure.lang.PersistentArrayMap/create {:a 1, :b 2})". This is invalid EDN (https://github.com/edn-format/edn). EDN does support tags, but the above isn't a tag. For a correct version of EDN from a webserver see https://github.com/tailrecursion/ring-edn. Anyway, this fixes things so it spits out valid EDN.
