### PR TITLE
PUT to a non-existing resource should return 404.

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -285,7 +285,7 @@
 
 (defhandler handle-not-implemented 501 "Not implemented.")
 
-(defdecision can-put-to-missing? conflict? handle-not-implemented)
+(defdecision can-put-to-missing? conflict? handle-not-found)
 
 (defdecision put-to-different-url? handle-moved-permanently can-put-to-missing?)
 

--- a/test/test_flow.clj
+++ b/test/test_flow.clj
@@ -105,7 +105,7 @@
                   :exists? false
                   :can-put-to-missing? false)
       resp (r (request :put "/"))]
-  (fact "Put to missing can give 501" resp => NOT-IMPLEMENTED))
+  (fact "Put to missing can give 404" resp => NOT-FOUND))
 
 (let [r (resource :method-allowed? [:put]
                   :exists? false
@@ -124,12 +124,12 @@
       (fact resp => OK)
       (fact resp => (content-type "text/plain;charset=UTF-8"))
       (fact resp => (no-body))))
-  
+
   (facts "unexisting resource"
     (let [resp ((resource :exists? false :handle-not-found "NOT-FOUND") (request :head "/"))]
       (fact resp => NOT-FOUND)
       (fact resp => (no-body))))
-  
+
   (facts "on moved temporarily"
     (let [resp ((resource :exists? false
                           :existed? true


### PR DESCRIPTION
RFC2616 §9.6 states
   "If the resource could not be created or modified with the
    Request-URI, an appropriate error response SHOULD be given
    that reflects the nature of the problem."

For me this should be a 404

I saw the comment in
https://github.com/clojure-liberator/liberator/issues/31

```
"I think 404 would be the most appropriate when we can guarantee
 that there never will be created a resource at this URI via PUT.
 Else 405 or 409 might be more appropriate."
```

I don't think this is correct, we don't need to consider whether a resource might be created at this resource, the RFC says...

RFC2616 §10.4.5

   "The server has not found anything matching the Request-URI. No
    indication is given of whether the condition is temporary or
    permanent."
