### PR TITLE
Improve debugability of resource anonymous functions.

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -608,10 +608,13 @@
   (if (vector? (first kvs))
     (let [args (first kvs)
           kvs (rest kvs)]
+      ;; Rather than call resource, create anonymous fn in callers namespace for better debugability.
       `(defn ~name [~@args]
-         (resource ~@kvs)))
-    `(def ~name 
-       (resource ~@kvs))))
+         (fn [~'request]
+           (run-resource ~'request (get-options (list ~@kvs))))))
+    `(def ~name
+         (fn [~'request]
+           (run-resource ~'request (get-options (list ~@kvs)))))))
 
 (defn by-method
   "returns a handler function that uses the request method to


### PR DESCRIPTION
When you build up a map of routes -> resources it is helpful to have the
resource handler fn named in a way that helps finding the source.

the `defresource` macro eventually makes a call to `liberator.core/resource`
which returns an anonymous handler function. If resource is a function
the anonymous function it returns is defined in the `liberator.core`
namespace which gives all resources a similar name.

However, If we make resource a macro, then the anonymous function is defined in
the callers namespace, this makes tracking down "I'm somehow routing to
the wrong handler" bugs much easier to debug, because the anonymous function
name in stacktraces changes from something like:

`#<core$resource$fn__15560 liberator.core$resource$fn__15560@4d8afb22>`

to

`#<project$project$fn__41618 kixi.hecuba.api.project$project$fn__41618@2068bdce>`

One alternative would be to maintain resource as a function for users to call, but change
the `defresource` macro to generate the anonymous function directly rather
than calling `liberator.core/resource`.

A second alternative would be to include the resource name in the
anoymous function, but that prevents resources with the same name in
different namespaces.

The approach in this commit seems minimally invasive whilst adding some
debugability.
