### PR TITLE
correct format string to show exception message

### DIFF
--- a/tutorial/all-together.md
+++ b/tutorial/all-together.md
@@ -61,7 +61,7 @@ into liberator.
         {:message "No body"})
       (catch Exception e
         (.printStackTrace e)
-        {:message (format "IOException: " (.getMessage e))}))))
+        {:message (format "IOException: %s" (.getMessage e))}))))
 
 ;; For PUT and POST check if the content type is json.
 (defn check-content-type [ctx content-types]


### PR DESCRIPTION
In example code, the format string did not show the error message as %s was missing. Fixed in this patch.
