### PR TITLE
fixed decision-graph tutorial example

### DIFF
--- a/tutorial/decision-graph.md
+++ b/tutorial/decision-graph.md
@@ -80,7 +80,7 @@ useful when we want to pass along a value to a handler:
                                         (get ctx :choice)))
                  :handle-not-found (fn [ctx]
                                      (format "<html>There is no value for the option &quot;%s&quot;"
-                                             (get ctx :choice "")))))
+                                             (get-in ctx [:request :params "choice"] "")))))
 {% endhighlight %}
 
 In this example we check if there is an entry in a map for the


### PR DESCRIPTION
On the handle-not-found it was trying to get the responde from the changed context, but that is not present into the handle-not-found (since the `if-let` statement will not run), so, I fixed by using the original requested choice instead of the generated one
