### PR TITLE
added the posts definition the POST example

### DIFF
--- a/tutorial/post-et-al.md
+++ b/tutorial/post-et-al.md
@@ -33,6 +33,8 @@ details please refer to the decision graph.
 An idiomatic way to support post is the following:
 
 {% highlight clojure %}
+  (def posts (ref []))
+  ;;...
   (ANY "/postbox" []
        (resource
         :allowed-methods [:post :get]


### PR DESCRIPTION
I got stuck for a little time on this demo because it misses the definition of the `posts` variable, I think having it on the example will help future users to don't have the same issue that I had.
