### PR TITLE
Removed old dependencies on tools.logging and tools.trace.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,6 @@
 (defproject liberator "0.12.0-SNAPSHOT"
   :description "Liberator - A REST library for Clojure."
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.clojure/tools.trace "0.7.3"]
-                 [org.clojure/tools.logging "0.2.3"]
                  [org.clojure/data.json "0.2.1"]
                  [org.clojure/data.csv "0.1.2"]
                  [hiccup "1.0.3"]] ;; Used by code rendering default representations.

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -11,8 +11,7 @@
   (:use
    [liberator.util :only [parse-http-date http-date as-date make-function]]
    [liberator.representation :only [Representation as-response ring-response]]
-   [clojure.string :only [join upper-case]]
-   [clojure.tools.trace :only [trace]])
+   [clojure.string :only [join upper-case]])
   (:import (javax.xml.ws ProtocolException)))
 
 (defmulti coll-validator

--- a/src/liberator/dev.clj
+++ b/src/liberator/dev.clj
@@ -2,7 +2,6 @@
   (:use hiccup.core
         hiccup.page
         compojure.core
-        clojure.tools.trace
         [liberator.core :only [defresource]]
         [clojure.string :only [join]])
   (:require [liberator.core :as core]

--- a/test/checkers.clj
+++ b/test/checkers.clj
@@ -1,8 +1,7 @@
 (ns checkers
   "contains midje checkers to test ring responses"
   (:use midje.sweet
-        [clojure.string :only (lower-case)]
-        [clojure.tools.trace :only (trace)]))
+        [clojure.string :only (lower-case)]))
 
 (defchecker ignore-case [expected]
   (fn [actual] (or (and (nil? actual) (nil? expected))

--- a/test/test.clj
+++ b/test/test.clj
@@ -9,7 +9,6 @@
 (ns test
   (:use [liberator.core]
         [compojure.core :only [context ANY routes defroutes]]
-        [clojure.tools.trace]
         [hiccup.core]
         [ring.adapter.jetty]
         [ring.middleware.stacktrace :only (wrap-stacktrace)]

--- a/test/test_resource_definition.clj
+++ b/test/test_resource_definition.clj
@@ -1,7 +1,6 @@
 (ns test-resource-definition
   (:use liberator.core
-        midje.sweet
-        [clojure.tools.trace :only [trace]]))
+        midje.sweet))
 
 ;; test cases for different resource definitions
 


### PR DESCRIPTION
Both `tools.trace` and `tools.logging` were not used in the code.

Removing references and dependencies to reduce exposed libraries and potential source of conflicts.
