### PR TITLE
Add support for multi methods as decision fn.

### DIFF
--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -209,6 +209,10 @@
   (as-response [this context]
     (as-response (render-map-generic this context) context))
 
+  clojure.lang.MultiFn
+  (as-response [multi-fn context]
+    (as-response (multi-fn context) context))
+
   ;; If a string is returned, we should carry out the conversion of both the charset and the encoding.
   String
   (as-response [this {representation :representation}]
@@ -238,4 +242,3 @@
     response))
 
 (defn ring-response [map] (->RingResponse map))
-

--- a/test/test_defresource.clj
+++ b/test/test_defresource.clj
@@ -3,6 +3,14 @@
             [liberator.core :refer [defresource resource]]
             [ring.mock.request :refer [request header]]))
 
+(defmulti with-multimethod* identity)
+
+(defmethod with-multimethod* :default [_]
+  "with-multimethod")
+
+(defresource with-multimethod
+  :handle-ok with-multimethod*)
+
 (defresource without-param
   :handle-ok (fn [_] (format "The text is %s" "test")))
 
@@ -49,7 +57,10 @@
              => {:headers {"Vary" "Accept", "Content-Type" "application/json;charset=UTF-8"}, :body "The text is a poem", :status 200})
        (fact "it should work with only a standard config"
              (with-options-only {:request-method :get})
-             => {:headers {"Vary" "Accept", "Content-Type" "application/json;charset=UTF-8"}, :body "OK", :status 200}))
+             => {:headers {"Vary" "Accept", "Content-Type" "application/json;charset=UTF-8"}, :body "OK", :status 200})
+       (fact "should allow multi methods as handlers"
+             (with-multimethod {:request-method :get})
+             => {:headers {"Content-Type" "text/plain;charset=UTF-8"}, :body "with-multimethod", :status 200}))
 
 
 (def fn-with-options
@@ -74,4 +85,3 @@
     => {:headers {"Vary" "Accept", "Content-Type" "application/json;charset=UTF-8"}, :body "The text is this", :status 200})
     (fn-with-options-only {:request-method :get})
     => {:headers {"Vary" "Accept", "Content-Type" "application/json;charset=UTF-8"}, :body "OK", :status 200})
-


### PR DESCRIPTION
This PR adds an implementation of the `Representation` protocol for
`clojure.lang.MultiFn`. This enables the direct use of multi methods as
decision functions, instead of the workaround `#(my-multi %)`.
Fixes #128.
