### PR TITLE
Fix #138. Allow decisions to return functions

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,12 @@
 # Changelog
 
+# New in 0.11.1
+
+## Bugs fixed
+
+* #138 context update deeply merges values. Support workaround
+  by enabling to evaluate a returned 0-ary function
+
 # New in 0.11.0
 
 * #97 Adds support for a default resource definition map parameter

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject liberator "0.11.0"
+(defproject liberator "0.11.1"
   :description "Liberator - A REST library for Clojure."
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/tools.trace "0.7.3"]

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -78,8 +78,14 @@
    (and (vector? curr) (vector? newval)) (vec (concat curr newval))
    :otherwise newval))
 
+(defn update-context [context context-update]
+  (cond
+   (map? context-update) (combine context context-update)
+   (fn? context-update) (context-update)
+   :otherwise context))
+
 (defn decide [name test then else {:keys [resource request] :as context}]
-  (if (or (fn? test) (contains? resource name)) 
+  (if (or (fn? test) (contains? resource name))
     (let [ftest (or (resource name) test)
 	  ftest (make-function ftest)
 	  fthen (make-function then)
@@ -87,8 +93,7 @@
 	  decision (ftest context)
 	  result (if (vector? decision) (first decision) decision)
 	  context-update (if (vector? decision) (second decision) decision)
-	  context (if (map? context-update)
-                    (combine context context-update) context)]
+	  context (update-context context context-update)]
       (log! :decision name decision)
       ((if result fthen felse) context))
     {:status 500 :body (str "No handler found for key \""  name "\"."

--- a/test/test_execution_model.clj
+++ b/test/test_execution_model.clj
@@ -22,7 +22,19 @@
     (-> (request :get "/")
         ((resource :exists? [true  {:a 1}]
                    :handle-ok #(ring-response %))))
-    => (contains {:a 1 :status 200})))
+    => (contains {:a 1 :status 200}))
+  (fact "vector concated to context value"
+    (-> (request :get "/")
+        ((resource :service-available? {:a [1]}
+                   :exists? {:a [2]}
+                   :handle-ok #(ring-response %))))
+    => (contains {:a [1 2] :status 200}))
+  (fact "function returned as context is evaluated"
+        (-> (request :get "/")
+            ((resource :service-available? {:a [1]}
+                       :exists? (fn [ctx] #(assoc ctx :a [2]))
+                       :handle-ok #(ring-response %))))
+        => (contains {:a [2] :status 200})))
 
 (facts "falsey return values"
   (fact (-> (request :get "/")


### PR DESCRIPTION
If a decision returns a function which is expected to take no arguments
then the function's return value is used as the updated context.

This allows to circumvent the deep merge of maps and lists which context
updates do by default.
