### PR TITLE
Fix some reflection warnings

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -64,7 +64,7 @@
     (if-let [etag-val (f context)]
       (format "\"%s\"" etag-val))))
 
-(defn gen-last-modified [context]
+(defn ^java.util.Date gen-last-modified [context]
   (if-let [f (get-in context [:resource :last-modified])]
     (if-let [lm-val (f context)]
       (as-date lm-val))))
@@ -227,7 +227,7 @@
 
 (defmethod to-location clojure.lang.APersistentMap [this] this)
 
-(defmethod to-location java.net.URL [url] (to-location (.toString url)))
+(defmethod to-location java.net.URL [^java.net.URL url] (to-location (.toString url)))
 
 (defmethod to-location nil [this] this)
 

--- a/src/liberator/dev.clj
+++ b/src/liberator/dev.clj
@@ -22,11 +22,11 @@
   (swap! logs #(->> (conj % [id msg])
                     (take log-size))))
 
-(defn- with-slash [s] (if (.endsWith s "/") s (str s "/")))
+(defn- with-slash [^String s] (if (.endsWith s "/") s (str s "/")))
 
 (def ^:dynamic *current-id* nil)
 
-(defn seconds-ago [d]
+(defn seconds-ago [^Date d]
   (int  (/ (- ( System/currentTimeMillis) (.getTime d)) 1000)))
 
 (defn log-by-id [id]

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -179,7 +179,7 @@
     (render-seq-generic data (assoc-in context [:representation :media-type]
                                        "application/json"))))
 
-(defn in-charset [string charset]
+(defn in-charset [^String string ^String charset]
   (if (and charset (not (.equalsIgnoreCase charset "UTF-8")))
     (java.io.ByteArrayInputStream.
      (.getBytes string (java.nio.charset.Charset/forName charset)))

--- a/src/liberator/util.clj
+++ b/src/liberator/util.clj
@@ -24,14 +24,14 @@
   nil
   (as-date [this] nil))
 
-(defn http-date-format []
+(defn ^SimpleDateFormat http-date-format []
   (let [df (new SimpleDateFormat
                 "EEE, dd MMM yyyy HH:mm:ss z"
                 Locale/US)]
     (do (.setTimeZone df (TimeZone/getTimeZone "GMT"))
         df)))
 
-(defn relative-date [future]
+(defn relative-date [^long future]
   (Date. (+ (System/currentTimeMillis) future)))
 
 (defn http-date [date]


### PR DESCRIPTION
> Reflection warning, liberator/util.clj:35:3 - call to java.util.Date ctor can't be resolved.
> Reflection warning, liberator/util.clj:38:16 - call to method format can't be resolved (target class is unknown).
> Reflection warning, liberator/util.clj:44:7 - call to method parse can't be resolved (target class is unknown).
> Reflection warning, liberator/representation.clj:183:25 - call to method equalsIgnoreCase can't be resolved (target class is unknown).
> Reflection warning, liberator/representation.clj:185:6 - call to method getBytes can't be resolved (target class is unknown).
> Reflection warning, liberator/core.clj:230:56 - reference to field toString can't be resolved.
> Reflection warning, liberator/core.clj:339:27 - call to method after can't be resolved (target class is unknown).
> Reflection warning, liberator/core.clj:376:13 - call to method after can't be resolved (target class is unknown).
> Reflection warning, liberator/dev.clj:25:27 - call to method endsWith can't be resolved (target class is unknown).
> Reflection warning, liberator/dev.clj:30:43 - reference to field getTime can't be resolved.
