### PR TITLE
Don't discard HEAD. Fixes #148

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -203,10 +203,8 @@
      (merge-with merge
                  {:headers (build-options-headers resource)}
                  response)
-      
-      (= :head (:request-method request))
-        (dissoc response :body)
-      :else response)))
+
+     :else response)))
 
 (defmacro ^:private defhandler [name status message]
   `(defn ~name [context#]

--- a/test/test_flow.clj
+++ b/test/test_flow.clj
@@ -123,12 +123,12 @@
     (let [resp ((resource :exists? true :handle-ok "OK") (request :head "/"))]
       (fact resp => OK)
       (fact resp => (content-type "text/plain;charset=UTF-8"))
-      (fact resp => (no-body))))
+      (fact resp => (body "OK"))))
   
   (facts "unexisting resource"
     (let [resp ((resource :exists? false :handle-not-found "NOT-FOUND") (request :head "/"))]
       (fact resp => NOT-FOUND)
-      (fact resp => (no-body))))
+      (fact resp => (body "NOT-FOUND"))))
   
   (facts "on moved temporarily"
     (let [resp ((resource :exists? false


### PR DESCRIPTION
I suppose another way of fixing this would be to compute the length as if for a GET and use that for the "Content-Length" but considering there might be middleware somewhere that alters it (e.g. gzip), it seems easier to just pass along the body and allow it to be dealt with at the edge.
