### PR TITLE
Update copyright information & get rid of headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) Philipp Meier (meier@fnogol.de). All rights reserved.
+Copyright (c) The Liberator developers. All rights reserved.
 
 The use and distribution terms for this software are covered by the Eclipse
 Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php) which

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -1,11 +1,3 @@
-;; Copyright (c) Philipp Meier (meier@fnogol.de). All rights reserved.
-;; The use and distribution terms for this software are covered by the Eclipse
-;; Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php) which
-;; can be found in the file epl-v10.html at the root of this distribution. By
-;; using this software in any fashion, you are agreeing to be bound by the
-;; terms of this license. You must not remove this notice, or any other, from
-;; this software.
-
 (ns liberator.core
   (:require [liberator.conneg :as conneg])
   (:use

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -1,11 +1,3 @@
-;; Copyright (c) Philipp Meier (meier@fnogol.de). All rights reserved.
-;; The use and distribution terms for this software are covered by the Eclipse
-;; Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php) which
-;; can be found in the file epl-v10.html at the root of this distribution. By
-;; using this software in any fashion, you are agreeing to be bound by the
-;; terms of this license. You must not remove this notice, or any other, from
-;; this software.
-
 (ns liberator.representation
   (:require
    [clojure.data.json :as json]

--- a/test/test.clj
+++ b/test/test.clj
@@ -1,11 +1,3 @@
-;; Copyright (c) Philipp Meier (meier@fnogol.de). All rights reserved.
-;; The use and distribution terms for this software are covered by the Eclipse
-;; Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php) which
-;; can be found in the file epl-v10.html at the root of this distribution. By
-;; using this software in any fashion, you are agreeing to be bound by the
-;; terms of this license. You must not remove this notice, or any other, from
-;; this software.
-
 (ns test
   (:use [liberator.core]
         [compojure.core :only [context ANY routes defroutes]]


### PR DESCRIPTION
Only a few source files contained a copyright notice and according to
The Software Freedom Law Center[1] this is not strictly necessary.

[1] http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html
