### PR TITLE
Wrap and merge functions when merging options

### DIFF
--- a/examples/clj/sandbox.clj
+++ b/examples/clj/sandbox.clj
@@ -1,0 +1,32 @@
+(ns sandbox
+  (:require [clojure.string :as str]
+            [liberator.core :refer [defresource wrap]]))
+
+(defn wrap-authorized-token [token-check-fn]
+  {:authorized?
+   (wrap 
+    (fn [f]
+      (fn [{{{authentication "WWW-Authenticate"} :headers} :request :as ctx}]
+        (if-let [[scheme token] (str/split (or authentication "") #"\s+")]
+          (if (= scheme "Token")
+            (if (token-check-fn token)
+              (f ctx)
+              [false {:message "Not authorized. Invalid token!"}])
+            [false {:message "Not authorized, please specify Token in WWW-Authenticate header"}])))))
+   :handle-unauthorized
+   (wrap (fn [h] (fn [ctx] (or (h ctx) (:message ctx)))))})
+
+
+(defresource token-authorized
+  (wrap-authorized-token #(= % "tiger"))
+  {:authorized? (fn [{{{q :q} :params} :request}]
+                  (or (not= q "forbidden")
+                      [false {:message "parameter q must not be \"forbidden\". "}]))
+   :handle-unauthorized :message})
+
+
+(token-authorized {:request-method :get
+                   :headers {"WWW-Authenticate" "Token tiger"}
+                   :params {:q "some"}})
+  
+

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -266,8 +266,6 @@
 
 (defdecision can-post-to-gone? post! handle-gone)
 
-
-
 (defdecision post-to-gone? (partial =method :post) can-post-to-gone? handle-gone)
 
 (defdecision moved-temporarily? handle-moved-temporarily post-to-gone?)
@@ -600,15 +598,35 @@
        ::throwable e}))) ; ::throwable gets picked up by an error renderer
 
 
+(defrecord Update [f])
+
+(defn update [f] (Update. f))
+
+(defrecord Wrap [f])
+(defn wrap [f] (Wrap. f))
+
+(defmulti combine-option (fn [x y] (type y)))
+
+(defmethod combine-option Update [x y]
+  (fn [& args]
+    ((.f y) (apply (make-function x) args))))
+
+(defmethod combine-option Wrap [x y]
+  ((.f y) (make-function x)))
+
+(defmethod combine-option :default [x y]
+  y)
+
 (defn get-options
-  [kvs]
-  (if (map? (first kvs))
-    (merge (first kvs) (apply hash-map (rest kvs)))
-    (apply hash-map kvs)))
+  [head & tail]
+  (if (map? head)
+    (merge-with combine-option head (when tail (apply get-options tail)))
+    (apply hash-map head tail)))
 
 (defn resource [& kvs]
-  (fn [request]
-    (run-resource request (get-options kvs))))
+  (let [options (apply get-options kvs)]
+    (fn [request]
+      (run-resource request options))))
 
 (defmacro defresource [name & kvs]
   (if (vector? (first kvs))
@@ -616,11 +634,13 @@
           kvs (rest kvs)]
       ;; Rather than call resource, create anonymous fn in callers namespace for better debugability.
       `(defn ~name [~@args]
-         (fn [~'request]
-           (run-resource ~'request (get-options (list ~@kvs))))))
+         (let [options# (get-options ~@kvs)]
+           (fn [request#]
+             (run-resource request# options#)))))
     `(def ~name
-         (fn [~'request]
-           (run-resource ~'request (get-options (list ~@kvs)))))))
+       (fn [request#]
+         (let [options# (get-options ~@kvs)]
+           (run-resource request# options#))))))
 
 (defn by-method
   "returns a handler function that uses the request method to


### PR DESCRIPTION
Experimental extension to enable the wrapping and merging of
functions defined as defaults:

````clojure
(defresource foo
  {:exists? (...) } ;; some default
  {:exists? (wrap (fn [f] (fn [ctx] ...)))}   ;; f is the default above
              ;; do sth with f and ctx and return something
  {...}  ;; even more defaults
  :exists? true ...) ;; or kws args at the end
````
See examples/clj/sandbox.clj for a potential application.

### TODO

find out how to handler different orders of wrapping. I.e. make an earlier definition wrap a later definition, or how to force it the other way round:

Option a) 

`(defresource foo {:a f1} {:a (wrap f2)})`. Here f2 wraps f1

Option b)

maybe `(defresource foo {:a f1} (:a (wrapped f2)})`, so that f1 wraps f2