### PR TITLE
Allow decisions to be multi-methods

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -71,7 +71,9 @@
 (declare handle-exception)
 
 (defn decide [name test then else {:keys [resource request] :as context}]
-  (if (or (fn? test) (contains? resource name))
+  (if (or (fn? test)
+          (instance? clojure.lang.MultiFn test)
+          (contains? resource name))
     (try
       (let [ftest (or (resource name) test)
             ftest (make-function ftest)

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -201,10 +201,6 @@
   (as-response [this context]
     (as-response (render-map-generic this context) context))
 
-  clojure.lang.MultiFn
-  (as-response [multi-fn context]
-    (as-response (multi-fn context) context))
-
   ;; If a string is returned, we should carry out the conversion of both the charset and the encoding.
   String
   (as-response [this {representation :representation}]

--- a/src/liberator/util.clj
+++ b/src/liberator/util.clj
@@ -5,7 +5,11 @@
            java.util.Date))
 
 (defn make-function [x]
-  (if (or (fn? x) (keyword? x)) x (constantly x)))
+  (if (or (fn? x)
+          (instance? clojure.lang.MultiFn x)
+          (keyword? x))
+    x
+    (constantly x)))
 
 (defn apply-if-function [function-or-value request]
   (if (fn? function-or-value)


### PR DESCRIPTION
This is a rather simple patch that allows multi-methods as decisions.

I've found it useful to break apart the implementation of decisions such as :allowed? or :processable? based upon :request-method.

As handlers can be multi-methods, maybe it's also fair to allow decisions?