### PR TITLE
avoid capturing the value of the as-response protocol fn

### DIFF
--- a/test/test_representation.clj
+++ b/test/test_representation.clj
@@ -139,3 +139,16 @@
 
   (fact "it cannot parse exotic content"
     (parsable-content-type? {:request {:headers {"content-type" "foobar/foo"}}}) => false))
+
+(defrecord TestRecord [])
+
+(extend-protocol Representation
+  TestRecord
+  (as-response [_ _]
+    (as-response "works great" nil)))
+
+(facts "Can extend Representation protocol after compiling liberator.core"
+  (fact (-> (mock/request :get "/")
+            ((resource :available-media-types ["text/plain"]
+                       :handle-ok (->TestRecord))))
+        => (contains {:status 200})))


### PR DESCRIPTION
Before this change, the `:as-response` entry in `default-functions` captures
the _value_ of the protocol fn `as-response` when `core.clj` is loaded. If
the `Represenation` protocol is later extended, those extensions are _not_
seen by the captured fn. After this change, extensions made after
`core.clj` is loaded _are_ available to be used in processing the
resource.

The usual way to avoid this kind of capture when storing a reference to
a Clojure function is to store the function's var itself rather than that
var's value. Doing that in this case causes tests to fail with
exceptions related to how the function/var is called. In contrast, the
proposed solution of using an anonymous wrapper function works well.
