### PR TITLE
checkers/all allowed failing checkers

### DIFF
--- a/test/checkers.clj
+++ b/test/checkers.clj
@@ -25,7 +25,7 @@
 (def OK (is-status 200))
 (def CREATED (is-status 201))
 (def ACCEPTED (is-status 202))
-(def NO-CONTENT (every-checker (is-status 204) (body nil?)))
+(def NO-CONTENT (every-checker (is-status 204) (no-body)))
 
 (defn status-location [status location]
   (every-checker (is-status status)


### PR DESCRIPTION
Failing midje/checkers return data about the failure and not false,
therefore failed checkers evaluate to true in every? and caused failing
tests to pass.

Delete checkers/all and replace with every-checker which performs the
same task but reports information about the first failing checker.