### PR TITLE
retain original handler result in metadata.

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -126,6 +126,11 @@
            {"Accept-Patch" (join "," ((:patch-content-types resource)))}
            {})))
 
+(defn handler-result->response
+  [{:keys [as-response]} context handler-result]
+  (when-let [response (as-response handler-result context)]
+    (vary-meta response assoc :liberator/value handler-result)))
+
 (defn run-handler [name status message
                    {:keys [resource request representation] :as context}]
   (let [context
@@ -172,12 +177,10 @@
             ;; override the status and headers.
 
 
-            (let [as-response (:as-response resource)]
-              (as-response
-               (if-let [handler (get resource (keyword name))]
-                 (handler context)
-                 (get context :message))
-               context)))))]
+            (->> (if-let [handler (get resource (keyword name))]
+                   (handler context)
+                   (get context :message))
+                 (handler-result->response resource context)))))]
     (cond
      (or (= :options (:request-method request)) (= 405 (:status response)))
      (merge-with merge


### PR DESCRIPTION
**Summary**

This MR would add the key `:liberator/value` - containing the original/raw value - to responses generated by `run-handler`.

**Reason**

To be able to verify response bodies (e.g. against a schema) one currently has to decode the content-negotiated-and-then-encoded data that Liberator resources produce (which is neither pretty nor always easily feasible). Alternatively, one can use `ring-response` to override the body, resulting in losing the value that the content negotiation provides.

Performing verification on the raw value seems reasonable and could be facilitated using the proposed changes.
