### PR TITLE
support java.net.URI for location

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -2,6 +2,9 @@
 
 # Unreleased
 
+* #201 Add support for using a java.net.URI instance to specify
+  a Location for `moved` handlers
+
 # New in 0.14.1
 
 * Improved highlighting of tracing view

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -204,6 +204,8 @@
 
 (defmethod to-location clojure.lang.APersistentMap [this] this)
 
+(defmethod to-location java.net.URI [^java.net.URI uri] (to-location (.toString uri)))
+
 (defmethod to-location java.net.URL [^java.net.URL url] (to-location (.toString url)))
 
 (defmethod to-location nil [this] this)

--- a/test/test_resource.clj
+++ b/test/test_resource.clj
@@ -2,15 +2,19 @@
   (:use clojure.test)
   (:use liberator.core))
 
-(deftest test-handle-post
-  (let [res (resource 
-	   :method-allowed? [:post]
-	   :can-post-to-missing? true
-	   :post-is-create? true
-           :post-redirect? true
-	   :location "new-path")
-	resp (res {:request-method :post :header {}})]
-    (testing "post creates path"
-      (is (= 303 (resp :status)))
-      (is (= "new-path" (get-in resp [:headers "Location"]))))))
+(def url "http://clojure-liberator.github.io")
 
+(deftest test-handle-post
+  (doseq [location [url
+                    (java.net.URL. url)
+                    (java.net.URI. url)]]
+    (let [res (resource
+               :method-allowed? [:post]
+               :can-post-to-missing? true
+               :post-is-create? true
+               :post-redirect? true
+               :location location)
+          resp (res {:request-method :post :header {}})]
+      (testing "post creates path"
+        (is (= 303 (resp :status)))
+        (is (= url (get-in resp [:headers "Location"])))))))


### PR DESCRIPTION
I switched from using URL to URI in a project because I hit this issue: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6519518 and read the recommendation from Sun/Oracle at the bottom: prefer using URI over URL for working with URLs.

I am able to work around liberator's lack of built-in support for java.net.URI for to-location, but built-in support seems worthwhile.
