### PR TITLE
Fix #206: avoid undesired deep merge of context when using ETag/If-Match...

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -361,7 +361,8 @@
 (defdecision  if-unmodified-since-valid-date?
   (fn [context]   
     (if-let [date (parse-http-date (get-in context [:request :headers  "if-unmodified-since"]))]
-      (assoc context ::if-unmodified-since-date date) context))
+      {::if-unmodified-since-date date}
+      {}))
   unmodified-since?
   if-none-match-exists?)
 
@@ -372,7 +373,7 @@
   (fn [context]
     (let [etag (gen-etag context)]
       [(= etag (get-in context [:request :headers "if-match"]))
-       (assoc context ::etag etag)]))
+       {::etag etag}]))
   if-unmodified-since-exists?
   handle-precondition-failed)
 

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -360,9 +360,8 @@
 
 (defdecision  if-unmodified-since-valid-date?
   (fn [context]   
-    (if-let [date (parse-http-date (get-in context [:request :headers  "if-unmodified-since"]))]
-      {::if-unmodified-since-date date}
-      {}))
+    (when-let [date (parse-http-date (get-in context [:request :headers "if-unmodified-since"]))]
+      {::if-unmodified-since-date date}))
   unmodified-since?
   if-none-match-exists?)
 

--- a/test/test_execution_model.clj
+++ b/test/test_execution_model.clj
@@ -56,22 +56,22 @@
                    :handle-ok :some-key)))
     => (contains {:status 200 :body "foo"})))
 
-(facts "no undesired deep merge of context"
+(facts "context merge leaves nested objects intact (see #206)"
   (fact "using etag and if-match"
     (-> (request :put "/")
         (header "if-match" "\"1\"")
         ((resource :allowed-methods [:put]
                    :available-media-types ["application/edn"]
-                   :malformed? (constantly [false {:my-entity {:deeply [:nested :object]}}])
+                   :malformed? [false {:my-entity {:deeply [:nested :object]}}]
                    :handle-created :my-entity
-                   :etag (constantly "1"))))
+                   :etag "1")))
     => (contains {:status 201, :body "{:deeply [:nested :object]}"}))
   (fact "using if-unmodified-since"
     (-> (request :put "/")
         (header "if-unmodified-since" "Tue, 15 Nov 1994 12:45:26 GMT")
         ((resource :allowed-methods [:put]
                    :available-media-types ["application/edn"]
-                   :malformed? (constantly [false {:my-entity {:deeply [:nested :object]}}])
+                   :malformed? [false {:my-entity {:deeply [:nested :object]}}]
                    :handle-created :my-entity
-                   :last-modified (constantly (java.util.Date. 0)))))
+                   :last-modified (java.util.Date. 0))))
     => (contains {:status 201, :body "{:deeply [:nested :object]}"})))

--- a/test/test_execution_model.clj
+++ b/test/test_execution_model.clj
@@ -8,7 +8,7 @@
 
 (facts "truethy return values"
   (fact (-> (request :get "/")
-             ((resource :exists?y true)))
+             ((resource :exists? true)))
     => (contains {:status 200}))
   (fact (-> (request :get "/")
              ((resource :exists? 1)))
@@ -55,3 +55,23 @@
         ((resource :exists? {:some-key "foo"}
                    :handle-ok :some-key)))
     => (contains {:status 200 :body "foo"})))
+
+(facts "no undesired deep merge of context"
+  (fact "using etag and if-match"
+    (-> (request :put "/")
+        (header "if-match" "\"1\"")
+        ((resource :allowed-methods [:put]
+                   :available-media-types ["application/edn"]
+                   :malformed? (constantly [false {:my-entity {:deeply [:nested :object]}}])
+                   :handle-created :my-entity
+                   :etag (constantly "1"))))
+    => (contains {:status 201, :body "{:deeply [:nested :object]}"}))
+  (fact "using if-unmodified-since"
+    (-> (request :put "/")
+        (header "if-unmodified-since" "Tue, 15 Nov 1994 12:45:26 GMT")
+        ((resource :allowed-methods [:put]
+                   :available-media-types ["application/edn"]
+                   :malformed? (constantly [false {:my-entity {:deeply [:nested :object]}}])
+                   :handle-created :my-entity
+                   :last-modified (constantly (java.util.Date. 0)))))
+    => (contains {:status 201, :body "{:deeply [:nested :object]}"})))


### PR DESCRIPTION
... or If-Unmodified-Since.

Also fixes what I presume was a typo in another test: ":exists?y" -> ":exists?".