### PR TITLE
Send location header for status 301, 303 and 307, too. 

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -146,7 +146,7 @@
            {:headers {"Last-Modified" (http-date last-modified)}})
 
          ;; 201 created required a location header to be send
-         (when (= 201 status)
+         (when (#{201 301 303 307} status)
            (if-let [f (or (get context :location)
                           (get resource :location))]
              {:headers {"Location" (str ((make-function f) context))}}))

--- a/test/checkers.clj
+++ b/test/checkers.clj
@@ -31,6 +31,11 @@
   (every-checker (is-status status)
                  (header-value "Location" location)))
 
+(defn status-location [status location]
+  (every-checker
+   (is-status status)
+   (header-value "Location" location)))
+
 (defn MOVED-PERMANENTLY [location] (status-location 301 location))
 (defn SEE-OTHER [location] (status-location 303 location))
 (def  NOT-MODIFIED (is-status 304))

--- a/test/test_flow.clj
+++ b/test/test_flow.clj
@@ -24,6 +24,15 @@
               (request :get "/"))]
     (fact resp => (MOVED-TEMPORARILY "http://new.example.com/"))))
 
+(facts "get on moved temporarily with custom handler"
+       (let [resp ((resource :exists? false
+                             :existed? true
+                             :moved-temporarily? {:location "http://new.example.com/"}
+                             :handle-moved-temporarily "Temporary redirection...")
+              (request :get "/"))]
+         (fact resp => (MOVED-TEMPORARILY "http://new.example.com/"))
+         (fact resp => (body "Temporary redirection..."))))
+
 (facts "get on moved permantently"
   (let [resp ((resource :exists? false :existed? true
                         :moved-permanently? true
@@ -33,14 +42,13 @@
 
 (facts "get on moved permantently with custom response"
   (let [resp ((resource :exists? false :existed? true
-                        :moved-permanently? true
-                        :handle-moved-permanently (ring-response {:body "Not here, there!"
-                                                                  :headers {"Location" "http://other.example.com/"}}))
+                        :moved-permanently? {:location "http://other.example.com/"}
+                        :handle-moved-permanently "Not here, there!")
               (request :get "/"))]
     (fact resp => (MOVED-PERMANENTLY "http://other.example.com/"))
     (fact resp => (body "Not here, there!"))))
 
-(facts "get on moved permantently with custom response"
+(facts "get on moved permantently with custom response and explicit header"
   (let [resp ((resource :exists? false :existed? true
                         :moved-permanently? true
                         :handle-moved-permanently (ring-response {:body "Not here, there!"
@@ -124,12 +132,12 @@
       (fact resp => OK)
       (fact resp => (content-type "text/plain;charset=UTF-8"))
       (fact resp => (no-body))))
-  
+
   (facts "unexisting resource"
     (let [resp ((resource :exists? false :handle-not-found "NOT-FOUND") (request :head "/"))]
       (fact resp => NOT-FOUND)
       (fact resp => (no-body))))
-  
+
   (facts "on moved temporarily"
     (let [resp ((resource :exists? false
                           :existed? true


### PR DESCRIPTION
With this patch, liberator adds a "Location" header for status 301, 303 and 307. @timvisher, does this fix it for you? 

Fixes fixes #212 