### PR TITLE
Fix typos and forgotten end tags in tutorial

### DIFF
--- a/tutorial/all-together.md
+++ b/tutorial/all-together.md
@@ -146,7 +146,7 @@ Here we use the syntax to define parametrized resources:
 hand-in-hand with compojure's routing parameters:
 
 {% highlight clojure %}
-(defroute collection-example
+(defroutes collection-example
     (ANY ["/collection/:id{[0-9]+}"] [id] (entry-resource id))
     (ANY "/collection" [] list-resource))
 {% endhighlight %}

--- a/tutorial/debugging.md
+++ b/tutorial/debugging.md
@@ -40,7 +40,7 @@ make the trace ui easily accessible:
   (ANY "/dbg-count" [] dbg-resource))
 
 (def handler
-  (-> app
+  (-> dbg
       (wrap-trace :header :ui)))
 {% endhighlight %}
 

--- a/tutorial/decision-graph.md
+++ b/tutorial/decision-graph.md
@@ -76,7 +76,7 @@ useful when we want to pass along a value to a handler:
                                           (get-in ctx [:request :params "choice"]))]
                               {:choice choice}))
                  :handle-ok (fn [ctx]
-                              (format "<html>Your choice: &quot;%s&quot;."
+                              (format "<html>Your choice: &quot;%s&quot;.</html>"
                                         (get ctx :choice)))
                  :handle-not-found (fn [ctx]
                                      (format "<html>There is no value for the option &quot;%s&quot;"

--- a/tutorial/post-et-al.md
+++ b/tutorial/post-et-al.md
@@ -43,7 +43,7 @@ An idiomatic way to support post is the following:
         :available-media-types ["text/html"]
         :handle-ok (fn [ctx]
                      (format  (str "<html>Post text/plain to this resource.<br>\n"
-                                   "There are %d posts at the moment.")
+                                   "There are %d posts at the moment.</html>")
                               (count @posts)))
         :post! (fn [ctx]
                  (dosync 
@@ -66,7 +66,7 @@ was made since it checked the resource:
         :available-media-types ["text/html"]
         :handle-ok (fn [ctx]
                      (format  (str "<html>Post text/plain to this resource.<br>\n"
-                                   "There are %d posts at the moment.")
+                                   "There are %d posts at the moment.</html>")
                               (count @posts)))
         :post! (fn [ctx]
                  (dosync 


### PR DESCRIPTION
While going through the tutorial, I've found some typos, so there goes.