### PR TITLE
Fix tutorial by bumping Compojure version

### DIFF
--- a/tutorial/getting-started.md
+++ b/tutorial/getting-started.md
@@ -30,7 +30,7 @@ Add dependencies to project.clj:
   :ring {:handler liberator-tutorial.core/handler}
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [liberator "0.10.0"]
-                 [compojure "1.1.3"]
+                 [compojure "1.3.4"]
                  [ring/ring-core "1.2.1"]])
 {% endhighlight %}
 


### PR DESCRIPTION
The tutorial uses inline regex syntax for routes, but these are only supported since Compojure 1.3.0, as https://github.com/weavejester/compojure/wiki/Routes-In-Detail explains:

> Or use inline regular expressions surrounded by braces (introduced in Compojure 1.3.0)