### PR TITLE
Add initialize action and basic test

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,10 @@
 # Changelog
 
+# Unreleased
+
+* Values can be added to the context at the beginning of the execution
+  flow using the :initialize-context action.
+
 # New in 0.13
 
 * Optionally a value can be specified for ring-response

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -492,6 +492,8 @@
 (defhandler handle-service-not-available 503 "Service not available.")
 (defdecision service-available? known-method? handle-service-not-available)
 
+(defaction initialize-context service-available?)
+
 (defhandler handle-exception 500 "Internal server error.")
 
 (defn handle-exception-rethrow [{e :exception}]
@@ -505,6 +507,8 @@
 
 (def default-functions
   {
+   :initialize-context {}
+
    ;; Decisions
    :service-available?        true
 
@@ -575,9 +579,8 @@
 ;; resources are a map of implementation methods
 (defn run-resource [request kvs]
   (try
-    (service-available? {:request request
-                         :resource
-                         (map-values make-function (merge default-functions kvs))
+    (initialize-context {:request request
+                         :resource (map-values make-function (merge default-functions kvs))
                          :representation {}})
     
     (catch ProtocolException e         ; this indicates a client error

--- a/test/test_flow.clj
+++ b/test/test_flow.clj
@@ -5,7 +5,10 @@
         checkers
         [ring.mock.request :only [request header]]))
 
-
+(facts "customize the initial context"
+       (let [resp ((resource :initialize-context {::field "some initial context"}
+                             :handle-ok ::field) (request :get "/"))]
+         (fact resp => (body "some initial context"))))
 
 (facts "get existing resource"
   (let [resp ((resource :exists? true :handle-ok "OK") (request :get "/"))]


### PR DESCRIPTION
Currently, there isn't an explicit way to customize the initial value of the context when handling a request, leading to ad-hoc methods (such as using the 'service-available?' decision point).

This pull request adds an 'initialize' action prior to 'service-available?' which provides this option.

I'll also add a pull request to the gh-pages branch with updated documentation.