### PR TITLE
Revise introduction to PATCH

### DIFF
--- a/tutorial/getting-started.md
+++ b/tutorial/getting-started.md
@@ -10,7 +10,7 @@ This part will give you a quick start into programming with liberator.
 
 Liberator is available from clojars. Add liberator to your project.clj as
 
-````[liberator "0.10.0"]````
+````[liberator "0.13"]````
 
 <div class="alert alert-info">The latest release might be newer, but the tutorial works at least
 with this version.</div>
@@ -29,7 +29,7 @@ Add dependencies to project.clj:
   :plugins [[lein-ring "0.8.11"]]
   :ring {:handler liberator-tutorial.core/handler}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [liberator "0.10.0"]
+                 [liberator "0.13"]
                  [compojure "1.3.4"]
                  [ring/ring-core "1.2.1"]])
 {% endhighlight %}

--- a/tutorial/post-et-al.md
+++ b/tutorial/post-et-al.md
@@ -5,10 +5,11 @@ title: Tutorial - Handling POST, et al.
 # Handling POST, et al.
 
 There's more than GET and HEAD requests. To be a useful web library
-you better support POST, PUT and DELETE as well, and so does
-liberator. While there are even more HTTP methods than those, liberator
-has no out-of-the-box support for them and treat them like GET requests.
-In any case you need to declare them as known and allowed.
+you better support POST, PUT, PATCH and DELETE as well, and so does
+liberator. While there are even more HTTP methods than those,
+liberator has no out-of-the-box support for them and treats them like
+GET requests. In any case you need to declare them as known and
+allowed.
 
 ## Enabling the methods
 
@@ -18,9 +19,9 @@ default implementation for this decision uses the resource key
 matches the request method. When adding more methods to your resource,
 make sure that the method is declared as known in
 ````:known-methods````. By default, liberator knows the methods from
-RFC2616: GET, HEAD, PUT, POST, DELETE, OPTIONS, TRACE. Liberator 
-implemented support for PATCH as of version 0.12.
-See [RFC5789](http://tools.ietf.org/html/rfc5789) for PATCH details.
+RFC2616: GET, HEAD, PUT, POST, DELETE, OPTIONS, TRACE as well as PATCH
+from [RFC5789](http://tools.ietf.org/html/rfc5789) (since version
+0.12).
 
 ## POST
 


### PR DESCRIPTION
It is clearer to just depend on a version of liberator which does support PATCH to start with, so no need to touch the `project.clj` in later parts of the tutorial, because the older version did not support PATCH yet.

As far as I see, the tutorial works with 0.13 just the same.