### PR TITLE
extended representation to java.util.Map

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -2,7 +2,7 @@
 
 # Unreleased
 
-* Map serialization supports java.util.Map
+* Representation generator supports java.util.Map
 
 # New in 0.14.0
 

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+* Map serialization supports java.util.Map
+
 # New in 0.14.0
 
 * The `defresource` macro no longer implicitly binds `request`.

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -204,7 +204,7 @@
 
   java.util.Map
   (as-response [this context]
-    (as-response (render-map-generic this context) context))
+    (as-response (render-map-generic (into {} this) context) context))
 
   ;; If a string is returned, we should carry out the conversion of both the charset and the encoding.
   String

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -202,6 +202,10 @@
   (as-response [this context]
     (as-response (render-map-generic this context) context))
 
+  java.util.Map
+  (as-response [this context]
+    (as-response (render-map-generic this context) context))
+
   ;; If a string is returned, we should carry out the conversion of both the charset and the encoding.
   String
   (as-response [this {representation :representation}]

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -204,7 +204,7 @@
 
   java.util.Map
   (as-response [this context]
-    (as-response (render-map-generic (into {} this) context) context))
+    (as-response (render-map-generic (into (sorted-map) this) context) context))
 
   ;; If a string is returned, we should carry out the conversion of both the charset and the encoding.
   String

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -53,9 +53,10 @@
        (apply str)))
 
 (defn- render-map-csv [data sep]
-  (with-out-str
-    (csv/write-csv *out* [["name" "value"]] :newline :cr+lf :separator sep)
-    (csv/write-csv *out* (seq data) :newline :cr+lf :separator sep)))
+  (let [data (if (coll? data) data (into {} data))]
+    (with-out-str
+      (csv/write-csv *out* [["name" "value"]] :newline :cr+lf :separator sep)
+      (csv/write-csv *out* (seq data) :newline :cr+lf :separator sep))))
 
 (defmethod render-map-generic "text/csv" [data context]
   (render-map-csv data \,))
@@ -204,7 +205,7 @@
 
   java.util.Map
   (as-response [this context]
-    (as-response (render-map-generic (into (sorted-map) this) context) context))
+    (as-response (render-map-generic this context) context))
 
   ;; If a string is returned, we should carry out the conversion of both the charset and the encoding.
   String

--- a/test/test_representation.clj
+++ b/test/test_representation.clj
@@ -33,8 +33,7 @@
 (facts "Can produce representation from java.util.Map"
        (let [entity (doto (java.util.TreeMap.)
                       (.put :foo "bar")
-                      (.put :baz "qux"))
-             expected-clj (into (sorted-map) entity)]
+                      (.put :baz "qux"))]
          (tabular "Various media types are supported"
                   (as-response entity {:representation {:media-type ?media-type :charset "UTF-8"}})
                   => {:body ?body :headers { "Content-Type" (str ?media-type ";charset=UTF-8")}}
@@ -47,8 +46,8 @@
                                      "<tr><th>foo</th><td>bar</td></tr>"
                                      "</tbody></table></div>")
                   "application/json" (clojure.data.json/write-str entity)
-                  "application/clojure" (pr-str-dup expected-clj)
-                  "application/edn" (pr-str expected-clj))))
+                  "application/clojure" (pr-str-dup entity)
+                  "application/edn" (pr-str entity))))
 
 (facts "Can produce representations from a seq of maps"
        (let [entity [(sorted-map :foo 1 :bar 2) (sorted-map :foo 2 :bar 3)]]

--- a/test/test_representation.clj
+++ b/test/test_representation.clj
@@ -30,6 +30,25 @@
                   "application/clojure" (pr-str-dup entity)
                   "application/edn" (pr-str entity))))
 
+(facts "Can produce representation from java.util.Map"
+       (let [entity (doto (java.util.HashMap.)
+                      (.put :foo "bar")
+                      (.put :baz "qux"))]
+         (tabular "Various media types are supported"
+                  (as-response entity {:representation {:media-type ?media-type :charset "UTF-8"}})
+                  => {:body ?body :headers { "Content-Type" (str ?media-type ";charset=UTF-8")}}
+                  ?media-type   ?body
+                  "text/csv"    "name,value\r\n:baz,qux\r\n:foo,bar\r\n"
+                  "text/tab-separated-values" "name\tvalue\r\n:baz\tqux\r\n:foo\tbar\r\n"
+                  "text/plain"  "baz=qux\r\nfoo=bar"
+                  "text/html"   (str "<div><table><tbody>"
+                                     "<tr><th>baz</th><td>qux</td></tr>"
+                                     "<tr><th>foo</th><td>bar</td></tr>"
+                                     "</tbody></table></div>")
+                  "application/json" (clojure.data.json/write-str entity)
+                  "application/clojure" (pr-str-dup (into {} entity))
+                  "application/edn" (pr-str (into {} entity)))))
+
 (facts "Can produce representations from a seq of maps"
        (let [entity [(sorted-map :foo 1 :bar 2) (sorted-map :foo 2 :bar 3)]]
          (tabular "Various media types are supported"

--- a/test/test_representation.clj
+++ b/test/test_representation.clj
@@ -31,7 +31,7 @@
                   "application/edn" (pr-str entity))))
 
 (facts "Can produce representation from java.util.Map"
-       (let [entity (doto (java.util.HashMap.)
+       (let [entity (doto (java.util.TreeMap.)
                       (.put :foo "bar")
                       (.put :baz "qux"))]
          (tabular "Various media types are supported"

--- a/test/test_representation.clj
+++ b/test/test_representation.clj
@@ -33,7 +33,8 @@
 (facts "Can produce representation from java.util.Map"
        (let [entity (doto (java.util.TreeMap.)
                       (.put :foo "bar")
-                      (.put :baz "qux"))]
+                      (.put :baz "qux"))
+             expected-clj (into (sorted-map) entity)]
          (tabular "Various media types are supported"
                   (as-response entity {:representation {:media-type ?media-type :charset "UTF-8"}})
                   => {:body ?body :headers { "Content-Type" (str ?media-type ";charset=UTF-8")}}
@@ -46,8 +47,8 @@
                                      "<tr><th>foo</th><td>bar</td></tr>"
                                      "</tbody></table></div>")
                   "application/json" (clojure.data.json/write-str entity)
-                  "application/clojure" (pr-str-dup (into {} entity))
-                  "application/edn" (pr-str (into {} entity)))))
+                  "application/clojure" (pr-str-dup expected-clj)
+                  "application/edn" (pr-str expected-clj))))
 
 (facts "Can produce representations from a seq of maps"
        (let [entity [(sorted-map :foo 1 :bar 2) (sorted-map :foo 2 :bar 3)]]


### PR DESCRIPTION
There are many libraries that do not return a MapEquivalence. The code used to encode representation for MapEquivalence works also for java.util.Map. 