### PR TITLE
Allow "conflict" response when POSTing to an existing resource

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+* Posting to an existing resource checks for conflicts.
+
 # New in 0.14.0
 
 * The `defresource` macro no longer implicitly binds `request`.

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -267,7 +267,9 @@
 
 (defaction put! new?)
 
-(defdecision conflict? handle-conflict put!)
+(defdecision is-post-request? (partial =method :post) post! put!)
+
+(defdecision conflict? handle-conflict is-post-request?)
 
 (defhandler handle-not-implemented 501 "Not implemented.")
 
@@ -295,7 +297,7 @@
   conflict? multiple-representations?)
 
 (defdecision post-to-existing? (partial =method :post)
-  post! put-to-existing?)
+  conflict? put-to-existing?)
 
 (defhandler handle-accepted 202 "Accepted")
 

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -267,9 +267,9 @@
 
 (defaction put! new?)
 
-(defdecision is-post-request? (partial =method :post) post! put!)
+(defdecision method-post? (partial =method :post) post! put!)
 
-(defdecision conflict? handle-conflict is-post-request?)
+(defdecision conflict? handle-conflict method-post?)
 
 (defhandler handle-not-implemented 501 "Not implemented.")
 

--- a/test/checkers.clj
+++ b/test/checkers.clj
@@ -45,6 +45,7 @@
 (def CONFLICT (is-status 409))
 (def GONE (is-status 410))
 (def PRECONDITION-FAILED (is-status 412))
+(def UNPROCESSABLE (is-status 422))
 
 (def INTERNAL-SERVER-ERROR (is-status 500))
 (def NOT-IMPLEMENTED (is-status 501))

--- a/test/checkers.clj
+++ b/test/checkers.clj
@@ -42,6 +42,7 @@
 (defn MOVED-TEMPORARILY [location] (status-location 307 location))
 
 (def NOT-FOUND (is-status 404))
+(def CONFLICT (is-status 409))
 (def GONE (is-status 410))
 (def PRECONDITION-FAILED (is-status 412))
 

--- a/test/test_flow.clj
+++ b/test/test_flow.clj
@@ -10,142 +10,158 @@
                              :handle-ok ::field) (request :get "/"))]
          (fact resp => (body "some initial context"))))
 
-(facts "get existing resource"
-  (let [resp ((resource :exists? true :handle-ok "OK") (request :get "/"))]
-    (fact resp => OK)
-    (fact resp => (body "OK"))))
+(facts "GET Requests"
+       (facts "get existing resource"
+              (let [resp ((resource :exists? true :handle-ok "OK") (request :get "/"))]
+                (fact resp => OK)
+                (fact resp => (body "OK"))))
 
-(facts "get unexisting resource"
-  (let [resp ((resource :exists? false :handle-not-found "NOT-FOUND") (request :get "/"))]
-    (fact resp => NOT-FOUND)
-    (fact resp => (body "NOT-FOUND"))))
+       (facts "get unexisting resource"
+              (let [resp ((resource :exists? false :handle-not-found "NOT-FOUND") (request :get "/"))]
+                (fact resp => NOT-FOUND)
+                (fact resp => (body "NOT-FOUND"))))
 
-(facts "get on moved temporarily"
-       (let [resp ((resource :exists? false
-                             :existed? true
-                             :moved-temporarily? {:location "http://new.example.com/"})
-              (request :get "/"))]
-    (fact resp => (MOVED-TEMPORARILY "http://new.example.com/"))))
+       (facts "get on moved temporarily"
+              (let [resp ((resource :exists? false
+                                    :existed? true
+                                    :moved-temporarily? {:location "http://new.example.com/"})
+                          (request :get "/"))]
+                (fact resp => (MOVED-TEMPORARILY "http://new.example.com/"))))
 
-(facts "get on moved temporarily with custom handler"
-       (let [resp ((resource :exists? false
-                             :existed? true
-                             :moved-temporarily? {:location "http://new.example.com/"}
-                             :handle-moved-temporarily "Temporary redirection...")
-              (request :get "/"))]
-         (fact resp => (MOVED-TEMPORARILY "http://new.example.com/"))
-         (fact resp => (body "Temporary redirection..."))))
+       (facts "get on moved temporarily with custom handler"
+              (let [resp ((resource :exists? false
+                                    :existed? true
+                                    :moved-temporarily? {:location "http://new.example.com/"}
+                                    :handle-moved-temporarily "Temporary redirection...")
+                          (request :get "/"))]
+                (fact resp => (MOVED-TEMPORARILY "http://new.example.com/"))
+                (fact resp => (body "Temporary redirection..."))))
 
-(facts "get on moved permantently"
-  (let [resp ((resource :exists? false :existed? true
-                        :moved-permanently? true
-                        :location "http://other.example.com/")
-              (request :get "/"))]
-    (fact resp => (MOVED-PERMANENTLY "http://other.example.com/"))))
+       (facts "get on moved permantently"
+              (let [resp ((resource :exists? false :existed? true
+                                    :moved-permanently? true
+                                    :location "http://other.example.com/")
+                          (request :get "/"))]
+                (fact resp => (MOVED-PERMANENTLY "http://other.example.com/"))))
 
-(facts "get on moved permantently with custom response"
-  (let [resp ((resource :exists? false :existed? true
-                        :moved-permanently? {:location "http://other.example.com/"}
-                        :handle-moved-permanently "Not here, there!")
-              (request :get "/"))]
-    (fact resp => (MOVED-PERMANENTLY "http://other.example.com/"))
-    (fact resp => (body "Not here, there!"))))
+       (facts "get on moved permantently with custom response"
+              (let [resp ((resource :exists? false :existed? true
+                                    :moved-permanently? {:location "http://other.example.com/"}
+                                    :handle-moved-permanently "Not here, there!")
+                          (request :get "/"))]
+                (fact resp => (MOVED-PERMANENTLY "http://other.example.com/"))
+                (fact resp => (body "Not here, there!"))))
 
-(facts "get on moved permantently with custom response and explicit header"
-  (let [resp ((resource :exists? false :existed? true
-                        :moved-permanently? true
-                        :handle-moved-permanently (ring-response {:body "Not here, there!"
-                                                             :headers {"Location" "http://other.example.com/"}}))
-              (request :get "/"))]
-    (fact resp => (MOVED-PERMANENTLY "http://other.example.com/"))
-    (fact resp => (body "Not here, there!"))))
+       (facts "get on moved permantently with custom response and explicit header"
+              (let [resp ((resource :exists? false :existed? true
+                                    :moved-permanently? true
+                                    :handle-moved-permanently (ring-response {:body "Not here, there!"
+                                                                              :headers {"Location" "http://other.example.com/"}}))
+                          (request :get "/"))]
+                (fact resp => (MOVED-PERMANENTLY "http://other.example.com/"))
+                (fact resp => (body "Not here, there!"))))
 
-(facts "get on moved permantently with automatic response"
-  (let [resp ((resource :exists? false :existed? true
-                        :moved-permanently? true
-                        :location "http://other.example.com/")
-              (request :get "/"))]
-    (fact resp => (MOVED-PERMANENTLY "http://other.example.com/"))))
+       (facts "get on moved permantently with automatic response"
+              (let [resp ((resource :exists? false :existed? true
+                                    :moved-permanently? true
+                                    :location "http://other.example.com/")
+                          (request :get "/"))]
+                (fact resp => (MOVED-PERMANENTLY "http://other.example.com/")))))
 
-(let [r (resource :method-allowed? (request-method-in :post)
-                  :exists? true
-                  :handle-created "Created")
-      resp (r (request :post "/"))]
-  (fact "Post to existing" resp => CREATED)
-  (fact "Body of 201" resp => (body "Created")))
+(facts "POST Requests"
+       (let [r (resource :method-allowed? (request-method-in :post)
+                         :exists? true
+                         :handle-created "Created")
+             resp (r (request :post "/"))]
+         (fact "Post to existing" resp => CREATED)
+         (fact "Body of 201" resp => (body "Created")))
 
-(let [r (resource :method-allowed? (request-method-in :post)
-                  :exists? true
-                  :post-redirect? {:location "http://example.com/foo"})
-      resp (r (request :post "/")) ]
-  (fact "Post to existing resource and redirect" resp => (SEE-OTHER  "http://example.com/foo")))
+       (let [r (resource :method-allowed? (request-method-in :post)
+                         :exists? true
+                         :conflict? true)
+             resp (r (request :post "/"))]
+         (fact "Post to existing with conflict" resp => CONFLICT))
 
-(let [r (resource :method-allowed? (request-method-in :post)
-                  :exists? false
-                  :post-redirect? true
-                  :can-post-to-missing? true
-                  :location "http://example.com/foo")
-      resp (r (request :post "/")) ]
-  (fact "Post to missing can redirect" resp => (SEE-OTHER  "http://example.com/foo")))
+       (let [r (resource :method-allowed? (request-method-in :post)
+                         :exists? true
+                         :post-redirect? {:location "http://example.com/foo"})
+             resp (r (request :post "/")) ]
+         (fact "Post to existing resource and redirect" resp => (SEE-OTHER  "http://example.com/foo")))
 
-(let [r (resource :method-allowed? (request-method-in :post)
-                  :exists? false
-                  :location "foo"
-                  :can-post-to-missing? true)
-      resp (r (request :post "/")) ]
-  (fact "Post to missing if post to missing is allowed" resp => CREATED)
-  (fact "Location is set" resp => (contains {:headers (contains {"Location" "foo"})})))
+       (let [r (resource :method-allowed? (request-method-in :post)
+                         :exists? false
+                         :post-redirect? true
+                         :can-post-to-missing? true
+                         :location "http://example.com/foo")
+             resp (r (request :post "/")) ]
+         (fact "Post to missing can redirect" resp => (SEE-OTHER  "http://example.com/foo")))
 
-(let [r (resource :method-allowed? (request-method-in :post)
-                  :exists? false
-                  :can-post-to-missing? false
-                  :handle-not-found "not-found")
-      resp (r (request :post "/")) ]
-  (fact "Post to missing can give 404" resp => NOT-FOUND)
-  (fact "Body of 404" resp => (body "not-found")))
+       (let [r (resource :method-allowed? (request-method-in :post)
+                         :exists? false
+                         :location "foo"
+                         :can-post-to-missing? true)
+             resp (r (request :post "/")) ]
+         (fact "Post to missing if post to missing is allowed" resp => CREATED)
+         (fact "Location is set" resp => (contains {:headers (contains {"Location" "foo"})})))
 
-(let [r (resource :method-allowed? (request-method-in :post)
-                  :exists? true
-                  :can-post-to-missing? false)
-      resp (r (request :post "/")) ]
-  (fact "Post to existing if post to missing forbidden is allowed" resp => CREATED))
+       (let [r (resource :method-allowed? (request-method-in :post)
+                         :exists? false
+                         :can-post-to-missing? false
+                         :handle-not-found "not-found")
+             resp (r (request :post "/")) ]
+         (fact "Post to missing can give 404" resp => NOT-FOUND)
+         (fact "Body of 404" resp => (body "not-found")))
+
+       (let [r (resource :method-allowed? (request-method-in :post)
+                         :exists? true
+                         :can-post-to-missing? false)
+             resp (r (request :post "/")) ]
+         (fact "Post to existing if post to missing forbidden is allowed" resp => CREATED)))
+
+
+(facts "PUT requests"
+       (let [r (resource :method-allowed? [:put]
+                         :exists? false
+                         :can-put-to-missing? false)
+             resp (r (request :put "/"))]
+         (fact "Put to missing can give 501" resp => NOT-IMPLEMENTED))
+
+       (let [r (resource :method-allowed? [:put]
+                         :exists? false
+                         :can-put-to-missing? true)
+             resp (r (request :put "/"))]
+         (fact "Put to missing can give 201" resp => CREATED))
+
+       (let [r (resource :method-allowed? [:put]
+                         :exists? true
+                         :conflict? true)
+             resp (r (request :put "/"))]
+         (fact "Put to existing with conflict" resp => CONFLICT))
+       
+       (let [r (resource :method-allowed? [:put]
+                         :processable? false)
+             resp (r (request :put "/"))]
+         (fact "Unprocessable can give 422" resp => (is-status 422))))
 
 
 
-(let [r (resource :method-allowed? [:put]
-                  :exists? false
-                  :can-put-to-missing? false)
-      resp (r (request :put "/"))]
-  (fact "Put to missing can give 501" resp => NOT-IMPLEMENTED))
+(facts "HEAD requests"
+       (facts "on existing resource"
+              (let [resp ((resource :exists? true :handle-ok "OK") (request :head "/"))]
+                (fact resp => OK)
+                (fact resp => (content-type "text/plain;charset=UTF-8"))
+                (fact resp => (no-body))))
 
-(let [r (resource :method-allowed? [:put]
-                  :exists? false
-                  :can-put-to-missing? true)
-      resp (r (request :put "/"))]
-  (fact "Put to missing can give 201" resp => CREATED))
+       (facts "unexisting resource"
+              (let [resp ((resource :exists? false :handle-not-found "NOT-FOUND") (request :head "/"))]
+                (fact resp => NOT-FOUND)
+                (fact resp => (no-body))))
 
-(let [r (resource :method-allowed? [:put]
-                  :processable? false)
-      resp (r (request :put "/"))]
-  (fact "Unprocessable can give 422" resp => (is-status 422)))
-
-(facts "Head requests"
-  (facts "on existing resource"
-    (let [resp ((resource :exists? true :handle-ok "OK") (request :head "/"))]
-      (fact resp => OK)
-      (fact resp => (content-type "text/plain;charset=UTF-8"))
-      (fact resp => (no-body))))
-
-  (facts "unexisting resource"
-    (let [resp ((resource :exists? false :handle-not-found "NOT-FOUND") (request :head "/"))]
-      (fact resp => NOT-FOUND)
-      (fact resp => (no-body))))
-
-  (facts "on moved temporarily"
-    (let [resp ((resource :exists? false
-                          :existed? true
-                          :moved-temporarily? true
-                          :location "http://new.example.com/")
-                (request :get "/"))]
-      (fact resp => (MOVED-TEMPORARILY "http://new.example.com/"))
-      (fact resp => (no-body)))))
+       (facts "on moved temporarily"
+              (let [resp ((resource :exists? false
+                                    :existed? true
+                                    :moved-temporarily? true
+                                    :location "http://new.example.com/")
+                          (request :get "/"))]
+                (fact resp => (MOVED-TEMPORARILY "http://new.example.com/"))
+                (fact resp => (no-body)))))

--- a/test/test_flow.clj
+++ b/test/test_flow.clj
@@ -141,7 +141,7 @@
        (let [r (resource :method-allowed? [:put]
                          :processable? false)
              resp (r (request :put "/"))]
-         (fact "Unprocessable can give 422" resp => (is-status 422))))
+         (fact "Unprocessable can give 422" resp => UNPROCESSABLE)))
 
 
 


### PR DESCRIPTION
Summary of changes:
- "post-to-existing?"'s 'true' branch now directs to "conflict?"
- In order to distinguish between POST and PUT requests downstream of "conflict?", added a "method-post?" decision which is directed to by the 'false' branch of "conflict?".
- added tests and did some minor cleanup of the test_flow namespace.

I took this approach, rather than the [suggestion here](https://github.com/clojure-liberator/liberator/issues/107#issuecomment-104169547) as at some point, presumably we'd also like to channel post requests to 'conflict?' from 'can-post-to-missing?' and 'can-post-to-gone?'.  But it does feel a little messy --- perhaps this suggests that a larger-scale refactoring of the decision graph would be worthwhile?

I've also updated the docs and decision graph; happy to submit a pull request for the gh-pages if the approach I've taken here is basically fine.
