### PR TITLE
Improve JSON handling

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -2,6 +2,9 @@
 
 # Unreleased
 
+* Switch from `clojure.data.jdbc` to `cheshire` for faster, and
+  fancier JSON responses (pprinting, key-fn, escapes, date-formatting)
+
 # New in 0.14.1
 
 * Improved highlighting of tracing view

--- a/examples/clj/examples/collection.clj
+++ b/examples/clj/examples/collection.clj
@@ -1,7 +1,7 @@
 (ns examples.collection
   (:require [liberator.core :refer (defresource by-method)]
             [clojure.java.io :as io]
-            [clojure.data.json :as json]
+            [cheshire.core :as json]
             [liberator.dev :refer (wrap-trace)])
   (:import java.net.URL))
 
@@ -26,7 +26,7 @@
   (when (#{:put :post} (get-in context [:request :request-method]))
     (try
       (if-let [body (body-as-string context)]
-        (let [data (json/read-str body)]
+        (let [data (json/parse-string body)]
           [false {key data}])
         {:message "No body"})
       (catch Exception e
@@ -35,7 +35,7 @@
 
 (defn check-content-type [ctx content-types]
   (if (#{:put :post} (get-in ctx [:request :request-method]))
-    (or 
+    (or
      (some #{(get-in ctx [:request :headers "content-type"])}
            content-types)
      [false {:message "Unsupported Content-Type"}])

--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,8 @@
   :description "Liberator - A REST library for Clojure."
   :url "http://clojure-liberator.github.io/liberator"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/data.json "0.2.1"]
                  [org.clojure/data.csv "0.1.2"]
+                 [cheshire "5.5.0"]
                  [hiccup "1.0.3"]] ;; Used by code rendering default representations.
   :deploy-repositories  [["releases" :clojars]]
   :lein-release {:deploy-via :clojars}

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -1,6 +1,6 @@
 (ns liberator.representation
   (:require
-   [clojure.data.json :as json]
+   [cheshire.core :as json]
    [clojure.data.csv :as csv]
    [clojure.string :refer [split trim]]
    [liberator.util :as util]
@@ -64,7 +64,7 @@
   (render-map-csv data \tab))
 
 (defmethod render-map-generic "application/json" [data context]
-  (json/write-str data))
+  (json/generate-string data))
 
 (defn render-as-clojure [data]
   (binding [*print-dup* true]
@@ -124,7 +124,7 @@
   (render-seq-html-table data context :html))
 
 (defmethod render-seq-generic "application/json" [data _]
-  (json/write-str data))
+  (json/generate-string data))
 
 (defmethod render-seq-generic "application/clojure" [data _]
   (render-as-clojure data))
@@ -278,7 +278,7 @@
 
 (defmethod parse-request-entity "application/json" [ctx]
   (if-let [body (:body (:request ctx))]
-    {:request-entity (json/read-str (slurp body :encoding (encoding ctx)) :key-fn keyword)}
+    {:request-entity (json/parse-string (slurp body :encoding (encoding ctx)) keyword)}
     true))
 
 (defmethod parse-request-entity :default [ctx]

--- a/src/liberator/representation.clj
+++ b/src/liberator/representation.clj
@@ -123,8 +123,8 @@
 (defmethod  render-seq-generic "application/xhtml+xml" [data context]
   (render-seq-html-table data context :html))
 
-(defmethod render-seq-generic "application/json" [data _]
-  (json/generate-string data))
+(defmethod render-seq-generic "application/json" [data context]
+  (json/generate-string data (:json context)))
 
 (defmethod render-seq-generic "application/clojure" [data _]
   (render-as-clojure data))

--- a/test/test_representation.clj
+++ b/test/test_representation.clj
@@ -4,7 +4,7 @@
             [liberator.core :refer :all]
             [checkers :refer :all]
             [ring.mock.request :as mock]
-            [clojure.data.json :as json]))
+            [cheshire.core :as json]))
 
 ;; test for issue #19
 ;; https://github.com/clojure-liberator/liberator/pull/19
@@ -26,7 +26,7 @@
                                      "<tr><th>baz</th><td>qux</td></tr>"
                                      "<tr><th>foo</th><td>bar</td></tr>"
                                      "</tbody></table></div>")
-                  "application/json" (clojure.data.json/write-str entity)
+                  "application/json" (cheshire.core/generate-string entity)
                   "application/clojure" (pr-str-dup entity)
                   "application/edn" (pr-str entity))))
 
@@ -46,7 +46,7 @@
                                      "<tr><td>3</td><td>2</td></tr>"
                                      "</tbody>"
                                      "</table></div>")
-                  "application/json" (clojure.data.json/write-str entity)
+                  "application/json" (cheshire.core/generate-string entity)
                   "application/clojure" (pr-str-dup entity)
                   "application/edn" (pr-str entity))))
 
@@ -89,7 +89,7 @@
                       :handle-created (fn [ctx] (reset! request-entity (:request-entity ctx)) "created")
                       :processable? parse-request-entity)
           resp (r (-> (mock/request :post "/" )
-                      (mock/body (json/write-str {:foo "bar"}))
+                      (mock/body (json/generate-string {:foo "bar"}))
                       (mock/content-type "application/json")))]
       resp => (is-status 201)
       @request-entity => {:foo "bar"}))
@@ -100,7 +100,7 @@
                       :handle-created (fn [ctx] (reset! request-entity (:request-entity ctx)) "created")
                       :processable? parse-request-entity)
           resp (r (-> (mock/request :post "/" )
-                      (mock/body (json/write-str {:foo "bar"}))
+                      (mock/body (json/generate-string {:foo "bar"}))
                       (mock/content-type "application/json;charset=iso8859-15;profile=x-vnd-foo")))]
       resp => (is-status 201)
       @request-entity => {:foo "bar"}))


### PR DESCRIPTION
This replaces `clojure.data.json` with `cheshire`. It's configurable and twice as fast.

It also adds a `:json` options allow configuring json responses, supporting everything cheshire can handle:

  * a user defined `:key-fn` (for camelCasing responses and such) 
  * built-in pretty-printing
  * date formatting
  * escaping unicode

The JSON option is modeled after the existing `:fields` option for formatting tabular responses.

The tests and the changelog are updated as well -- plus a test for `:fields`.

[Here's the cleaner diff](https://github.com/clojure-liberator/liberator/pull/252/files?w=false)

