### PR TITLE
Update dependencies and tweak .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lib/
 .lein*
 /target
 _site
+profiles.clj

--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,9 @@
   :description "Liberator - A REST library for Clojure."
   :url "http://clojure-liberator.github.io/liberator"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/data.json "0.2.1"]
-                 [org.clojure/data.csv "0.1.2"]
-                 [hiccup "1.0.3"]] ;; Used by code rendering default representations.
+                 [org.clojure/data.json "0.2.6"]
+                 [org.clojure/data.csv "0.1.3"]
+                 [hiccup "1.0.5"]] ;; Used by code rendering default representations.
   :deploy-repositories  [["releases" :clojars]]
   :lein-release {:deploy-via :clojars}
 
@@ -16,22 +16,19 @@
   :scm {:connection "scm:git:https://github.com/clojure-liberator/liberator.git"
         :url "https://github.com/clojure-liberator/liberator"}
 
-  :plugins [[lein-midje "3.1.3" :exclusions [leiningen-core]]
-            [lein-ring "0.8.10" :exclusions [org.clojure/clojure]]]
+  :plugins [[lein-midje "3.2.1"]
+            [lein-ring "0.10.0"]]
 
-  :profiles {:dev {:dependencies [[ring/ring-jetty-adapter "1.2.1" :exclusions [joda-time]]
-                                  [ring-mock "0.1.2"]
-                                  [ring/ring-devel "1.2.1" :exclusions [joda-time]]
-                                  [midje "1.6.0" :exclusions [org.clojure/clojure]]
+  :profiles {:dev {:dependencies [[ring/ring-jetty-adapter "1.5.1"]
+                                  [ring-mock "0.1.5" :exclusions [ring/ring-codec]]
+                                  [ring/ring-devel "1.5.1"]
+                                  [midje "1.8.3"]
                                   ;; only for examples
-                                  [compojure "1.0.2" :exclusions [org.clojure/tools.macro]]
-                                  [org.clojure/clojurescript "0.0-1450"]]
+                                  [compojure "1.5.2"]
+                                  [org.clojure/clojurescript "1.7.145"]]
                    :source-paths [ "src" "examples/clj"]}
-             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0" :upgrade? false]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0" :upgrade? false]]}
              :dl  {:jvm-opts ["-Dclojure.compiler.direct-linking=true"]}
              :1.8dl [:1.8 :dl]}
 
@@ -42,4 +39,4 @@
          :adapter {:port 8000}}
 
   :aliases {"examples" ["run" "-m" "examples.server"]
-            "test-all" ["with-profile" "+1.4:+1.5:+1.6:+1.7:+1.8:+1.8dl" "test"]})
+            "test-all" ["with-profile" "+1.7:+1.8:+1.8dl" "test"]})


### PR DESCRIPTION
Update all dependencies to current versions and overhaul exclusions to ensure that dependencies are pedantically specified.

Tests with versions of Clojure older than 1.8 do *not* pass.  For versions prior to 1.7, the dependency clashes seemed substantial.  For version 1.7.0, the failure is due to the inability to compile the updated Clojurescript dependency.

The Clojurescript dependency was very old.  Given the pace of Clojurescript evolution since the last release of liberator, I think a hard choice needs to be made for future releases:
 
- Support old versions of Clojure but with poor Clojurescript support
- Drop support for old versions of Clojure and add support for current versions of Clojurescript.