### PR TITLE
Remove fixed width/height of 500px from decision graph svg

### DIFF
--- a/assets/img/decision-graph.svg
+++ b/assets/img/decision-graph.svg
@@ -2,8 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="500px" height="500px"
-     viewBox="0.00 -3937.00 2982.16 4000.00"
+<svg viewBox="0.00 -3937.00 2982.16 4000.00"
 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
 
 <script xlink:href="../js/svgpan.js"/>


### PR DESCRIPTION
The tutorial's decision graph page, https://clojure-liberator.github.io/liberator/tutorial/decision-graph.html, links to the raw SVG image at https://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg, but due to the `<svg>` element's fixed dimensions, is very small, and no easier to navigate than the embedded version.

Since the container (a `<span>` with `display: block`!) has fixed dimensions, this does not overflow in the constrained space of the tutorial, as you can see at https://chbrown.github.io/liberator/tutorial/decision-graph (this `patch-1` branch is already merged into the `gh-pages` branch in my fork)

Compare https://chbrown.github.io/liberator/assets/img/decision-graph.svg, which, in my opinion, is easier to explore.