### PR TITLE
Support for 202 for Post and Put actions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject liberator "0.14.1"
+(defproject liberator "0.14.2"
   :description "Liberator - A REST library for Clojure."
   :url "http://clojure-liberator.github.io/liberator"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -226,6 +226,8 @@
 
 (defhandler handle-multiple-representations 300 nil) ; nil body because the body is reserved to reveal the actual representations available.
 
+(defhandler handle-accepted 202 "Accepted")
+
 (defdecision multiple-representations? handle-multiple-representations handle-ok)
 
 (defdecision respond-with-entity? multiple-representations? handle-no-content)
@@ -236,11 +238,15 @@
 
 (defdecision post-redirect? handle-see-other new?)
 
+(defdecision post-enacted? post-redirect? handle-accepted)
+
+(defdecision put-enacted? new? handle-accepted)
+
 (defhandler handle-not-found 404 "Resource not found.")
 
 (defhandler handle-gone 410 "Resource is gone.")
 
-(defaction post! post-redirect?)
+(defaction post! post-enacted?)
 
 (defdecision can-post-to-missing? post! handle-not-found)
 
@@ -252,8 +258,6 @@
 (defhandler handle-moved-temporarily 307 nil)
 
 (defdecision can-post-to-gone? post! handle-gone)
-
-
 
 (defdecision post-to-gone? (partial =method :post) can-post-to-gone? handle-gone)
 
@@ -267,7 +271,7 @@
 
 (defaction patch! respond-with-entity?)
 
-(defaction put! new?)
+(defaction put! put-enacted?)
 
 (defdecision method-post? (partial =method :post) post! put!)
 
@@ -300,8 +304,6 @@
 
 (defdecision post-to-existing? (partial =method :post)
   conflict? put-to-existing?)
-
-(defhandler handle-accepted 202 "Accepted")
 
 (defdecision delete-enacted? respond-with-entity? handle-accepted)
 
@@ -542,6 +544,8 @@
    :can-put-to-missing?       true
    :moved-permanently?        false
    :moved-temporarily?        false
+   :post-enacted?             true
+   :put-enacted?              true 
    :delete-enacted?           true
    :processable?              true
 


### PR DESCRIPTION
Could this be taken up while #280 is in progress?
#It is adding support for asynchronus operations for put! and post!...
It adds post-enacted? decision point (default value as true) and put-enacted? decision point (default value as true) after post! and put! actions respectively. 
This implies if post!/put! is not complete, it redirects to handle-accepted (`202 Accepted`).

A new? generally would imply the post! or put! is completed, to further push things to `handle-created` or `respond-with-entity`. This is why an incompleted operation in progress is not passed to the nodes such as `post-redirect?` or `new?`.

I am yet to add the test cases. Please review the position of the decision points and give some insights.