### PR TITLE
fix for save-logs! to avoid 'GC overhead limit exceeded'

### DIFF
--- a/src/liberator/dev.clj
+++ b/src/liberator/dev.clj
@@ -20,7 +20,8 @@
 
 (defn save-log! [id msg]
   (swap! logs #(->> (conj % [id msg])
-                    (take log-size))))
+                    (take log-size)
+                    (doall))))
 
 (defn- with-slash [^String s] (if (.endsWith s "/") s (str s "/")))
 


### PR DESCRIPTION
This is a possible fix to the problem described in issue https://github.com/clojure-liberator/liberator/issues/295 concerning the error "GC overhead limit exceeded" caused by liberator.dev/logs.