### PR TITLE
Handle malformed Accept-Language Accept-Charset & Accept-Encoding

### DIFF
--- a/src/liberator/conneg.clj
+++ b/src/liberator/conneg.clj
@@ -163,10 +163,16 @@
 
 (defn split-qval [caq]
   (let [[charset & params] (string/split caq #"[\s\r\n]*;[\s\r\n]*")
+        parse (fn [s]
+                (let [[param value] (string/split s #"[\s\r\n]*=")
+                      failure (protocol-exception "Quality value of header is malformed")]
+                  (when (= "q" param)
+                    (try
+                      (Float/parseFloat value)
+                      (catch NumberFormatException e (throw failure))
+                      (catch NullPointerException e (throw failure))))))
         q (first (reverse (sort (filter (comp not nil?)
-                                        (map #(let [[param value] (string/split % #"[\s\r\n]*=")]
-                                                (if (= "q" param) (Float/parseFloat value)))
-                                             params)))))]
+                                        (map parse params)))))]
     (when (and
            (not (nil? q))
            (> q 1.0))

--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -417,13 +417,12 @@
   encoding-available? processable?)
 
 (defdecision charset-available?
-  #(try-header "Accept-Charset"
-               (when-let [charset (conneg/best-allowed-charset
-                                   (get-in % [:request :headers "accept-charset"])
-                                   ((get-in context [:resource :available-charsets]) context))]
-                 (if (= charset "*")
-                   true
-                   {:representation {:charset charset}})))
+  #(when-let [charset (conneg/best-allowed-charset
+                       (get-in % [:request :headers "accept-charset"])
+                       ((get-in context [:resource :available-charsets]) context))]
+     (if (= charset "*")
+       true
+       {:representation {:charset charset}}))
   accept-encoding-exists? handle-not-acceptable)
 
 (defdecision accept-charset-exists? (partial header-exists? "accept-charset")
@@ -431,13 +430,12 @@
 
 
 (defdecision language-available?
-  #(try-header "Accept-Language"
-               (when-let [lang (conneg/best-allowed-language
-                                (get-in % [:request :headers "accept-language"])
-                                ((get-in context [:resource :available-languages]) context))]
-                 (if (= lang "*")
-                   true
-                   {:representation {:language lang}})))
+  #(when-let [lang (conneg/best-allowed-language
+                   (get-in % [:request :headers "accept-language"])
+                   ((get-in context [:resource :available-languages]) context))]
+    (if (= lang "*")
+      true
+      {:representation {:language lang}}))
   accept-charset-exists? handle-not-acceptable)
 
 (defdecision accept-language-exists? (partial header-exists? "accept-language")

--- a/test/test_handler_context.clj
+++ b/test/test_handler_context.clj
@@ -34,6 +34,8 @@
       (negotiate "Accept-Language" :available-languages :language ?available ?accepted) => ?negotiated
       ?available ?accepted ?negotiated
       []          "en" 406
+      ["en"]      "en;q=garbage" 400
+      ["en"]      "en;q=" 400
       ["en"]      "en" "en"
       ["en" "de"] "de" "de"
       ["en" "de"] "de,fr" "de"
@@ -60,6 +62,7 @@
      ?available ?accepted ?negotiated
      []          "ascii" 406
      ["utf-8"]     "ascii" 406
+     ["utf-8"]     "ascii;q=0.7)" 400
      ["utf-8"]     "utf-8" "utf-8"
      ["ascii" "utf-8"] "utf-8" "utf-8"
      ["ascii" "utf-8"] "utf-8,fr" "utf-8"
@@ -72,6 +75,7 @@
      ?available ?accepted ?negotiated
      []            "gzip" "identity"
      ["gzip"]      "gzip" "gzip"
+     ["gzip"]      "gzip;q=foo" 400
      ["compress"]  "gzip" "identity"
      ["gzip" "compress"] "compress" "compress"
      ["gzip" "compress"] "compress,fr" "compress"


### PR DESCRIPTION
Fixes #199

Bad qvals (either out of range, not parsable to a float) in these headers will now cause a 400 status code to be returned.

I'm not overly happy with this because we are sending a 400 status code, but not passing through `handle-malformed` which means users of this library can't change the rendering by overriding `handle-malformed`. 

The best they can do is check for the `:liberator.core/throwable` key on the response and add custom handling in middleware (e.g. ring), which may be good enough.