### PR TITLE
Allow defresource to have a docstring

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -5,6 +5,7 @@
 * Remove old examples. These dependet on an ancient clojurescript
   version which blocked updating some dependencies
 * Update clojure versions in the build matrix.
+* Allow `defresource` to have a docstring (#305)
 
 ## Bugs fixed
 

--- a/test/test_defresource.clj
+++ b/test/test_defresource.clj
@@ -22,6 +22,10 @@
   :service-available? with-service-available?-multimethod*
   :handle-ok (fn [_] "with-service-available?-multimethod"))
 
+(defresource with-docstring
+  "This is a fancy docstring."
+  :handle-ok (fn [_] "OK"))
+
 (defresource without-param
   :handle-ok (fn [_] (format "The text is %s" "test")))
 
@@ -56,6 +60,9 @@
   :handle-ok (str request))
 
 (facts "about defresource"
+       (fact "a docstring can be optionally provided"
+             (with-docstring {:request-method :get})
+             => {:headers {"Content-Type" "text/plain;charset=UTF-8"}, :body "OK", :status 200})
        (fact "its simple form should behave as it always has"
              (without-param {:request-method :get})
              => {:headers {"Content-Type" "text/plain;charset=UTF-8"}, :body "The text is test", :status 200}


### PR DESCRIPTION
```
(defresource example
  "This is my awesome resource!"
  ...)
```

This resolves #243.