### PR TITLE
Never respond with 304 if last-modified is missing in response

### DIFF
--- a/src/liberator/core.clj
+++ b/src/liberator/core.clj
@@ -322,7 +322,7 @@
 (defdecision modified-since?
   (fn [context]
     (let [last-modified (gen-last-modified context)]
-      [(and last-modified (.after last-modified (::if-modified-since-date context)))
+      [(or (not last-modified) (.after last-modified (::if-modified-since-date context)))
        {::last-modified last-modified}]))
   method-delete?
   handle-not-modified)

--- a/test/test_conditionals.clj
+++ b/test/test_conditionals.clj
@@ -41,6 +41,13 @@
       (fact resp => (no-body))
       (fact resp => (header-value "Last-Modified" (http-date (as-date 1000))))))
 
+  (facts "if-modified-since false due to missing last-modified"
+    (let [resp ((resource :exists? true)
+                (-> (request :get "/")
+                    (if-modified-since (http-date (as-date 1000)))))]
+      (fact resp => 200)
+      (fact resp => (body "OK"))))
+
   (facts "if-unmodified-since true"
     (let [resp ((resource :exists? true
                           :last-modified (as-date 1000)


### PR DESCRIPTION
The default modified-since? decision would always evaluate to false
when the request contained an "if-modified-since" header but the
response didn't contain a "last-modified" header. This seems wrong
because the decision is not actually able to determine whether the
resource has been modified or not.

This patch makes it evaluate to true instead which seems more
reasonable in this situation.